### PR TITLE
Do not write zip data descriptor for empty files

### DIFF
--- a/include/burst_writer.h
+++ b/include/burst_writer.h
@@ -70,9 +70,10 @@ void burst_writer_destroy(struct burst_writer *writer);
 // Add a file to the archive
 // input_file: Open file handle to read from (caller must close)
 // lfh: Fully-constructed local file header (caller allocates)
+//      If lfh->flags has ZIP_FLAG_DATA_DESCRIPTOR set, the file is compressed and
+//      a data descriptor is written after the compressed data.
+//      If the flag is NOT set, the file is treated as empty (header-only, no data).
 // lfh_len: Total size of local file header including filename and extra fields
-// is_header_only: True for empty files or symlinks (no compressed data frames)
-//                 When true, ensures proper alignment by inserting padding LFH if needed
 // unix_mode: Unix file mode (permissions + file type) for central directory
 // uid: Unix user ID for extra field
 // gid: Unix group ID for extra field
@@ -80,7 +81,6 @@ int burst_writer_add_file(struct burst_writer *writer,
                           FILE *input_file,
                           struct zip_local_header *lfh,
                           int lfh_len,
-                          bool is_header_only,
                           uint32_t unix_mode,
                           uint32_t uid,
                           uint32_t gid);

--- a/src/writer/burst_writer.c
+++ b/src/writer/burst_writer.c
@@ -253,13 +253,17 @@ int burst_writer_add_file(struct burst_writer *writer,
                           FILE *input_file,
                           struct zip_local_header *lfh,
                           int lfh_len,
-                          bool is_header_only,
                           uint32_t unix_mode,
                           uint32_t uid,
                           uint32_t gid) {
     if (!writer || !input_file || !lfh || lfh_len <= 0) {
         return -1;
     }
+
+    // Determine if this is a header-only file (empty, no data descriptor)
+    // based on whether the LFH has the data descriptor flag set
+    // Used only in the case of empty files, so we do not read data in this case.
+    bool is_header_only = !(lfh->flags & ZIP_FLAG_DATA_DESCRIPTOR);
 
     // Get file size
     long file_size = 0;
@@ -322,14 +326,14 @@ int burst_writer_add_file(struct burst_writer *writer,
 
     size_t bytes_read;
 
-    // Handle header-only files (empty files with STORE method, symlinks)
-    // These have no data to compress, so skip directly to the data descriptor
+    // Handle header-only files (empty files with STORE method)
+    // These have no data to compress and no data descriptor (sizes known at LFH time)
     if (is_header_only) {
-        // For STORE method empty files: no data bytes at all
-        // The CRC is 0, sizes are 0, and we just write the data descriptor
+        // For STORE method empty files: no data bytes, no descriptor needed
+        // CRC is 0, sizes are 0, and these are already in the LFH
         free(input_buffer);
         free(output_buffer);
-        goto write_descriptor;
+        goto file_done;
     }
 
     // Otherwise this is a regular and non-empty file, so start writing compressed zstandard frames.
@@ -488,7 +492,6 @@ int burst_writer_add_file(struct burst_writer *writer,
         }
     }
 
-write_descriptor:
     // Write data descriptor (use ZIP64 if sizes exceed 32-bit limit)
     if (write_data_descriptor(writer, entry->crc32, entry->compressed_size,
                              entry->uncompressed_size, entry->used_zip64_descriptor) != 0) {
@@ -496,6 +499,7 @@ write_descriptor:
         return -1;
     }
 
+file_done:
     // Update statistics
     writer->total_uncompressed += entry->uncompressed_size;
     writer->total_compressed += entry->compressed_size;

--- a/src/writer/entry_processor.c
+++ b/src/writer/entry_processor.c
@@ -38,12 +38,15 @@ static struct zip_local_header* build_local_file_header(const char *filename, bo
 
     memset(lfh, 0, sizeof(struct zip_local_header));
     lfh->signature = ZIP_LOCAL_FILE_HEADER_SIG;
-    lfh->flags = ZIP_FLAG_DATA_DESCRIPTOR;
 
     if (is_empty) {
+        // Empty files have known sizes (0) at LFH time, so no data descriptor needed
+        lfh->flags = 0;
         lfh->version_needed = ZIP_VERSION_STORE;
         lfh->compression_method = ZIP_METHOD_STORE;
     } else {
+        // Non-empty files use data descriptor since sizes are unknown until compression
+        lfh->flags = ZIP_FLAG_DATA_DESCRIPTOR;
         lfh->version_needed = ZIP_VERSION_ZSTD;
         lfh->compression_method = ZIP_METHOD_ZSTD;
     }
@@ -250,7 +253,7 @@ int process_entry(struct burst_writer *writer,
             return 0;
         }
 
-        if (burst_writer_add_file(writer, input, lfh, lfh_len, is_empty,
+        if (burst_writer_add_file(writer, input, lfh, lfh_len,
                                   file_stat->st_mode, file_stat->st_uid, file_stat->st_gid) == 0) {
             success = 1;
         } else {

--- a/tests/integration/test_padding_lfh_extraction.c
+++ b/tests/integration/test_padding_lfh_extraction.c
@@ -115,7 +115,7 @@ void test_padding_real_file_then_lfh(void) {
     TEST_ASSERT_NOT_NULL(lfh);
 
     // Add real file to archive
-    int result = burst_writer_add_file(writer, input, lfh, lfh_len, false, 0100644, 0, 0);
+    int result = burst_writer_add_file(writer, input, lfh, lfh_len, 0100644, 0, 0);
     TEST_ASSERT_EQUAL(0, result);
 
     // 2. Write a padding LFH (100 bytes total)
@@ -202,7 +202,7 @@ void test_multiple_padding_lfhs(void) {
     input = fopen(temp_file, "rb");
     int lfh_len;
     struct zip_local_header *lfh = create_test_lfh("content.txt", false, &lfh_len);
-    burst_writer_add_file(writer, input, lfh, lfh_len, false, 0100644, 0, 0);
+    burst_writer_add_file(writer, input, lfh, lfh_len, 0100644, 0, 0);
     fclose(input);
     free(lfh);
     unlink(temp_file);
@@ -266,7 +266,7 @@ void test_padding_lfh_large_extra_field(void) {
     input = fopen(temp_file, "rb");
     int lfh_len;
     struct zip_local_header *lfh = create_test_lfh("after_large.txt", false, &lfh_len);
-    burst_writer_add_file(writer, input, lfh, lfh_len, false, 0100644, 0, 0);
+    burst_writer_add_file(writer, input, lfh, lfh_len, 0100644, 0, 0);
     fclose(input);
     free(lfh);
     unlink(temp_file);
@@ -323,7 +323,7 @@ void test_padding_lfh_zipinfo_count(void) {
         int lfh_len;
         struct zip_local_header *lfh = create_test_lfh(filename, false, &lfh_len);
 
-        burst_writer_add_file(writer, input, lfh, lfh_len, false, 0100644, 0, 0);
+        burst_writer_add_file(writer, input, lfh, lfh_len, 0100644, 0, 0);
 
         fclose(input);
         free(lfh);

--- a/tests/mocks/burst_writer_mock.h
+++ b/tests/mocks/burst_writer_mock.h
@@ -18,7 +18,6 @@ int burst_writer_add_file(void *writer,
                           FILE *input_file,
                           void *lfh,
                           int lfh_len,
-                          bool is_header_only,
                           uint32_t unix_mode,
                           uint32_t uid,
                           uint32_t gid);

--- a/tests/unit/test_writer_chunking.c
+++ b/tests/unit/test_writer_chunking.c
@@ -32,8 +32,8 @@ struct burst_writer;
 struct burst_writer* burst_writer_create(FILE* output, int compression_level);
 void burst_writer_destroy(struct burst_writer* writer);
 int burst_writer_add_file(struct burst_writer* writer, FILE* input_file,
-                          struct zip_local_header* lfh, int lfh_len, int next_lfh_len,
-                          bool is_header_only);
+                          struct zip_local_header* lfh, int lfh_len,
+                          uint32_t unix_mode, uint32_t uid, uint32_t gid);
 
 // Global call counters
 static int compress_chunk_call_count;
@@ -143,7 +143,7 @@ void test_file_exactly_128k_produces_one_chunk(void) {
     TEST_ASSERT_NOT_NULL(input);
 
     // Call with new API (next_lfh_len = 0 for single file tests)
-    int result = burst_writer_add_file(writer, input, lfh, lfh_len, 0, false);
+    int result = burst_writer_add_file(writer, input, lfh, lfh_len, 0100644, 0, 0);
 
     TEST_ASSERT_EQUAL(0, result);
     TEST_ASSERT_EQUAL(1, compress_chunk_call_count);
@@ -176,7 +176,7 @@ void test_file_128k_plus_one_produces_two_chunks(void) {
     TEST_ASSERT_NOT_NULL(input);
 
     // Call with new API (next_lfh_len = 0 for single file tests)
-    int result = burst_writer_add_file(writer, input, lfh, lfh_len, 0, false);
+    int result = burst_writer_add_file(writer, input, lfh, lfh_len, 0100644, 0, 0);
 
     TEST_ASSERT_EQUAL(0, result);
     TEST_ASSERT_EQUAL(2, compress_chunk_call_count);
@@ -209,7 +209,7 @@ void test_file_256k_produces_two_chunks(void) {
     TEST_ASSERT_NOT_NULL(input);
 
     // Call with new API (next_lfh_len = 0 for single file tests)
-    int result = burst_writer_add_file(writer, input, lfh, lfh_len, 0, false);
+    int result = burst_writer_add_file(writer, input, lfh, lfh_len, 0100644, 0, 0);
 
     TEST_ASSERT_EQUAL(0, result);
     TEST_ASSERT_EQUAL(2, compress_chunk_call_count);
@@ -241,7 +241,7 @@ void test_file_384k_minus_one_produces_three_chunks(void) {
     TEST_ASSERT_NOT_NULL(input);
 
     // Call with new API (next_lfh_len = 0 for single file tests)
-    int result = burst_writer_add_file(writer, input, lfh, lfh_len, 0, false);
+    int result = burst_writer_add_file(writer, input, lfh, lfh_len, 0100644, 0, 0);
 
     TEST_ASSERT_EQUAL(0, result);
     TEST_ASSERT_EQUAL(3, compress_chunk_call_count);
@@ -273,7 +273,7 @@ void test_chunks_never_exceed_128k(void) {
     TEST_ASSERT_NOT_NULL(input);
 
     // Call with new API (next_lfh_len = 0 for single file tests)
-    int result = burst_writer_add_file(writer, input, lfh, lfh_len, 0, false);
+    int result = burst_writer_add_file(writer, input, lfh, lfh_len, 0100644, 0, 0);
 
     TEST_ASSERT_EQUAL(0, result);
     // 200 KiB = 128 KiB + 72 KiB → 2 chunks


### PR DESCRIPTION
Zip [data descriptors](https://en.wikipedia.org/wiki/ZIP_(file_format)#Data_descriptor) are only useful when the file
length and checksum isn't known at LFH write time. For the case of empty
files, we do know those things, so we do not need to write a data
descriptor.

Also simplifies burst_writer_add_file function signature to remove a
redundant parameter specifying the LFH is for an empty file; we can
infer this by looking at the LFH that was passed in.

A Claude analysis reported no impacts to the downloader or to alignment
rule violations as a result of this change.
