### PR TITLE
Performance tests

### DIFF
--- a/.github/workflows/performance-test.yaml
+++ b/.github/workflows/performance-test.yaml
@@ -1,0 +1,251 @@
+name: BURST Performance Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch_ref:
+        description: 'Branch or ref to build burst-downloader from'
+        required: true
+        default: 'main'
+      s3_results_prefix:
+        description: 'S3 prefix for results (e.g., perf-run-2025-01-08)'
+        required: true
+      test_instance_types:
+        description: 'Comma-separated instance types to test'
+        required: false
+        default: 'i7ie.xlarge,i7ie.3xlarge,i7ie.12xlarge,m6id.4xlarge'
+      test_init_scripts:
+        description: 'Comma-separated init scripts to test'
+        required: false
+        default: 'setup_btrfs_root.sh,setup_btrfs_user.sh'
+      test_archives:
+        description: 'Comma-separated archive names to test'
+        required: false
+        default: 'verysmall,small,medium,medium-manyfiles,large,large-manyfiles,xlarge,xlarge-manyfiles,xxlarge'
+      cooldown_minutes:
+        description: 'Cooldown minutes between instance types (to avoid S3 performance interference)'
+        required: false
+        default: '45'
+
+permissions:
+  id-token: write  # Required for OIDC authentication
+  contents: read
+
+env:
+  AWS_REGION: us-west-2
+
+jobs:
+  # Build job - builds burst-downloader from specified branch
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      artifact-name: ${{ steps.upload.outputs.artifact-name }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.branch_ref }}
+
+    - name: Install build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libzstd-dev zlib1g-dev cmake
+
+    - name: Build burst-downloader
+      run: |
+        mkdir build && cd build
+        cmake -DBUILD_DOWNLOADER=ON -DCMAKE_BUILD_TYPE=Release ..
+        make burst-downloader -j$(nproc)
+
+    - name: Verify binary
+      run: |
+        ./build/burst-downloader --help
+
+    - name: Upload binary artifact
+      id: upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: burst-downloader-${{ inputs.branch_ref }}-${{ github.run_id }}
+        path: build/burst-downloader
+        retention-days: 1
+
+  # Generate test matrix
+  generate-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.generate.outputs.matrix }}
+      instance_types: ${{ steps.generate.outputs.instance_types }}
+
+    steps:
+    - name: Generate test matrix
+      id: generate
+      run: |
+        # Parse instance types and init scripts
+        IFS=',' read -ra INSTANCE_TYPES <<< "${{ inputs.test_instance_types }}"
+        IFS=',' read -ra INIT_SCRIPTS <<< "${{ inputs.test_init_scripts }}"
+
+        # Build matrix JSON
+        MATRIX='{"include":['
+        FIRST=true
+
+        for instance_type in "${INSTANCE_TYPES[@]}"; do
+          for init_script in "${INIT_SCRIPTS[@]}"; do
+            if [ "$FIRST" = true ]; then
+              FIRST=false
+            else
+              MATRIX+=','
+            fi
+            MATRIX+="{\"instance_type\":\"$instance_type\",\"init_script\":\"$init_script\"}"
+          done
+        done
+
+        MATRIX+=']}'
+
+        echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+        echo "instance_types=$(echo "${INSTANCE_TYPES[*]}" | tr ' ' ',')" >> $GITHUB_OUTPUT
+
+        echo "Generated matrix:"
+        echo "$MATRIX" | jq .
+
+  # Run performance tests - sequential execution with cooldown
+  # Uses max-parallel: 1 to ensure only one instance runs at a time
+  test-execution:
+    needs: [build, generate-matrix]
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 1  # Sequential execution - critical for S3 performance isolation
+      fail-fast: false  # Continue even if one test fails
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Download binary artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: burst-downloader-${{ inputs.branch_ref }}-${{ github.run_id }}
+        path: ./
+
+    - name: Make binary executable
+      run: chmod +x ./burst-downloader
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-region: us-west-2
+        role-to-assume: arn:aws:iam::339404546440:role/BurstPerformanceTests
+
+    - name: Determine if cooldown needed
+      id: cooldown-check
+      run: |
+        # Check if this is the first job for a new instance type by comparing with previous job
+        # We use a simple heuristic: cooldown after each instance type completes all init scripts
+        CURRENT_INSTANCE="${{ matrix.instance_type }}"
+        CURRENT_INIT="${{ matrix.init_script }}"
+
+        # Get list of init scripts
+        IFS=',' read -ra INIT_SCRIPTS <<< "${{ inputs.test_init_scripts }}"
+        LAST_INIT="${INIT_SCRIPTS[-1]}"
+
+        # Only add cooldown after the last init script for each instance type
+        if [ "$CURRENT_INIT" = "$LAST_INIT" ]; then
+          # Check if this is the last instance type
+          IFS=',' read -ra INSTANCE_TYPES <<< "${{ inputs.test_instance_types }}"
+          LAST_INSTANCE="${INSTANCE_TYPES[-1]}"
+
+          if [ "$CURRENT_INSTANCE" != "$LAST_INSTANCE" ]; then
+            echo "needs_cooldown=true" >> $GITHUB_OUTPUT
+          else
+            echo "needs_cooldown=false" >> $GITHUB_OUTPUT
+          fi
+        else
+          echo "needs_cooldown=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Run performance test
+      id: run-test
+      run: |
+        echo "Running performance test for ${{ matrix.instance_type }} with ${{ matrix.init_script }}"
+
+        # Run the orchestration script
+        ./tests/performance/run_perf_test_on_ec2.sh \
+          --instance-type "${{ matrix.instance_type }}" \
+          --init-script "${{ matrix.init_script }}" \
+          --archives "${{ inputs.test_archives }}" \
+          --binary-path ./burst-downloader \
+          --results-prefix "${{ inputs.s3_results_prefix }}"
+
+    - name: Retry on failure
+      if: failure() && steps.run-test.outcome == 'failure'
+      run: |
+        echo "First attempt failed, retrying..."
+        sleep 60
+
+        ./tests/performance/run_perf_test_on_ec2.sh \
+          --instance-type "${{ matrix.instance_type }}" \
+          --init-script "${{ matrix.init_script }}" \
+          --archives "${{ inputs.test_archives }}" \
+          --binary-path ./burst-downloader \
+          --results-prefix "${{ inputs.s3_results_prefix }}"
+
+    - name: Cooldown between instance types
+      if: steps.cooldown-check.outputs.needs_cooldown == 'true'
+      run: |
+        COOLDOWN_SECONDS=$((${{ inputs.cooldown_minutes }} * 60))
+        echo "Starting ${{ inputs.cooldown_minutes }} minute cooldown to avoid S3 performance interference..."
+        echo "Cooldown ends at: $(date -d "+$COOLDOWN_SECONDS seconds" -Iseconds)"
+        sleep $COOLDOWN_SECONDS
+        echo "Cooldown complete"
+
+  # Summary job - runs after all tests complete
+  summary:
+    needs: [test-execution]
+    runs-on: ubuntu-latest
+    if: always()
+
+    steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-region: us-west-2
+        role-to-assume: arn:aws:iam::339404546440:role/BurstPerformanceTests
+
+    - name: Download and display all results
+      run: |
+        echo "============================================"
+        echo "Performance Test Results Summary"
+        echo "============================================"
+        echo ""
+        echo "Results prefix: ${{ inputs.s3_results_prefix }}"
+        echo ""
+
+        # List all result files
+        echo "Result files:"
+        aws s3 ls "s3://burst-performance-results/${{ inputs.s3_results_prefix }}/" || echo "No results found"
+
+        echo ""
+        echo "============================================"
+        echo "Individual Results"
+        echo "============================================"
+
+        # Download and display each CSV
+        for csv_file in $(aws s3 ls "s3://burst-performance-results/${{ inputs.s3_results_prefix }}/" | awk '{print $4}'); do
+          echo ""
+          echo "--- $csv_file ---"
+          aws s3 cp "s3://burst-performance-results/${{ inputs.s3_results_prefix }}/$csv_file" - 2>/dev/null || echo "Failed to download"
+        done
+
+    - name: Create summary
+      run: |
+        echo "## Performance Test Results" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "- **Branch/Ref**: ${{ inputs.branch_ref }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Results Prefix**: ${{ inputs.s3_results_prefix }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Instance Types**: ${{ inputs.test_instance_types }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Init Scripts**: ${{ inputs.test_init_scripts }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Archives Tested**: ${{ inputs.test_archives }}" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "Results are stored in S3 at:" >> $GITHUB_STEP_SUMMARY
+        echo "\`s3://burst-performance-results/${{ inputs.s3_results_prefix }}/\`" >> $GITHUB_STEP_SUMMARY

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,3 +200,31 @@ GitHub Actions parallelizes tests automatically:
 The slow test matrix is built automatically from CMakeLists.txt labels - no manual maintenance required.
 
 Total: ~15-20 minutes (vs ~25-30 sequential)
+
+## Performance Testing Framework
+
+Located in [tests/performance/](tests/performance/), provides GitHub Actions workflow for benchmarking burst-downloader across EC2 instance types and archive sizes.
+
+- **Test Archives**: S3 bucket `burst-performance-tests` (5 MiB to 50 GiB)
+  - Each archive stored as both `{name}/archive.zip` and `{name}/files/*`
+  - Enables future comparison with non-BURST tools
+- **Results**: S3 bucket `burst-performance-results` (CSV files)
+- **Instance Types**: i7ie.xlarge, i7ie.3xlarge, i7ie.12xlarge, m6id.4xlarge (spot instances)
+- **Workflow**: [.github/workflows/performance-test.yaml](.github/workflows/performance-test.yaml)
+- **Technical Docs**: [tests/performance/README.md](tests/performance/README.md)
+- **User Guide**: [docs/performance-tests.md](docs/performance-tests.md)
+
+### Running Performance Tests
+
+```bash
+# Via GitHub Actions
+gh workflow run performance-test.yaml \
+  -f branch_ref=main \
+  -f s3_results_prefix=perf-$(date +%Y%m%d)
+
+# Create test archives (one-time setup)
+./tests/performance/create_perf_test_archives.sh
+```
+
+**Note**: Uses Ubuntu 24.04 spot instances in us-west-2 with self-termination on completion/error.
+Tests run sequentially with 45-minute cooldowns between instance types to ensure S3 performance isolation.

--- a/docs/performance-tests.md
+++ b/docs/performance-tests.md
@@ -1,0 +1,172 @@
+# BURST Performance Tests
+
+This document describes the performance testing framework for BURST, what it measures, and how to interpret results.
+
+## What Are BURST Performance Tests?
+
+BURST performance tests measure the download and extraction speed of `burst-downloader` under controlled conditions. The tests evaluate how quickly BURST can download archives of various sizes from S3 and extract them to different filesystem types.
+
+The framework is designed to:
+- Establish baseline performance metrics for different configurations
+- Identify performance improvements or regressions between versions
+- Compare performance across different EC2 instance types
+- Measure the impact of BTRFS compressed write optimization
+
+## Test Matrix
+
+### Instance Types
+
+We test on a variety of storage-optimized and general-purpose instances:
+
+| Instance Type | vCPUs | Memory | Network Bandwidth | Storage |
+|--------------|-------|--------|-------------------|---------|
+| **i7ie.xlarge** | 4 | 32 GiB | Up to 25 Gbps | NVMe SSD |
+| **i7ie.3xlarge** | 12 | 96 GiB | Up to 25 Gbps | NVMe SSD |
+| **i7ie.12xlarge** | 48 | 384 GiB | 75 Gbps | NVMe SSD |
+| **m6id.4xlarge** | 16 | 64 GiB | Up to 12.5 Gbps | NVMe SSD |
+
+These instances are chosen to represent common deployment scenarios and to evaluate how BURST scales with available resources.
+
+### Archive Sizes
+
+Tests cover a range of archive sizes representing different use cases:
+
+| Archive | Uncompressed Size | Files | Use Case |
+|---------|------------------|-------|----------|
+| **Very Small** | ~5 MiB | 1 | Quick deployments, config files |
+| **Small** | ~40 MiB | 1 | Small application packages |
+| **Medium** | ~250 MiB | 1 | Typical application deployments |
+| **Medium (many files)** | ~250 MiB | ~5,000 | Source code, many small files |
+| **Large** | ~1 GiB | 1 | Large applications, dependencies |
+| **Large (many files)** | ~1 GiB | ~10,000 | Large codebases |
+| **Extra Large** | ~10 GiB | 1 | ML models, large datasets |
+| **Extra Large (many files)** | ~10 GiB | ~25,000 | Very large projects |
+| **XXLarge** | ~50 GiB | 1 | Massive datasets |
+
+### Filesystem Configurations
+
+Each instance is tested with two BTRFS configurations to measure the performance impact of `BTRFS_IOC_ENCODED_WRITE`:
+
+1. **BTRFS as root**: BTRFS filesystem with zstd compression, running burst-downloader as root. This configuration enables BURST's `BTRFS_IOC_ENCODED_WRITE` optimization, which writes compressed data directly to disk without decompression/recompression. This ioctl requires elevated privileges.
+
+2. **BTRFS as user**: BTRFS filesystem with zstd compression, running burst-downloader as a regular user. This configuration prevents use of `BTRFS_IOC_ENCODED_WRITE`, forcing standard write operations. This isolates the performance benefit of the encoded write optimization.
+
+## What We Measure
+
+For each test, we collect the following metrics using `/usr/bin/time`:
+
+| Metric | Description |
+|--------|-------------|
+| **Wall Time** | Total elapsed time from start to finish (seconds) |
+| **User CPU Time** | Time spent in user-mode code (seconds) |
+| **System CPU Time** | Time spent in kernel-mode code (seconds) |
+| **Max Memory** | Peak memory usage (KB) |
+
+### Understanding the Metrics
+
+- **Wall time** is the primary metric for overall performance. Lower is better.
+
+- **User CPU time** reflects time spent on decompression and data processing. With BTRFS passthrough, this should be significantly reduced since data isn't decompressed.
+
+- **System CPU time** reflects I/O operations and kernel overhead. BTRFS with compression may show higher system time due to filesystem complexity, but this is offset by reduced user time.
+
+- **Wall time < User + System time** can occur when operations are parallelized across multiple CPU cores.
+
+## How Tests Ensure Isolation
+
+### Sequential Execution
+
+Tests are run sequentially, one instance at a time. This ensures:
+- No competition for S3 bandwidth between test instances
+- Consistent network conditions for each test
+- Predictable S3 performance (no hot/cold object effects)
+
+### Cooldown Periods
+
+A 45-minute cooldown period occurs between different instance types. This:
+- Allows S3's internal caching/distribution to stabilize
+- Prevents performance artifacts from recent accesses
+- Ensures each instance type encounters "fresh" S3 objects
+
+### Why This Matters
+
+S3 performance can be affected by concurrent or recent access patterns:
+- Objects with frequent access may be cached closer to the requestor
+- High concurrency can trigger throttling
+- Recent accesses can warm caches, improving subsequent performance
+
+By testing sequentially with cooldowns, we measure more consistent, reproducible performance.
+
+## Interpreting Results
+
+### Expected Patterns
+
+**By User Privilege:**
+- BTRFS as root typically shows the best wall time for large archives due to zero-copy writes via `BTRFS_IOC_ENCODED_WRITE`
+- BTRFS as user provides a baseline showing standard write performance without the encoded write optimization
+- The difference between these two configurations isolates the benefit of `BTRFS_IOC_ENCODED_WRITE`
+
+**By Archive Size:**
+- Throughput (MB/s) should remain relatively constant for single-file archives
+- Many-files archives may show lower throughput due to filesystem metadata operations
+- Very small archives may show higher relative overhead from S3 round-trips
+
+**By Instance Type:**
+- Larger instances should show better performance up to network saturation
+- i7ie.12xlarge with 75 Gbps network should significantly outperform others on large archives
+- CPU cores matter less than network and storage bandwidth for this workload
+
+### Identifying Issues
+
+**High exit_code values**: Tests that fail (exit_code != 0) indicate errors. Check the detailed logs in S3.
+
+**Unexpected variance**: If wall_time varies significantly between similar runs, investigate:
+- Spot instance type (may have different underlying hardware)
+- S3 regional capacity at time of test
+- Instance storage performance variability
+
+**No performance difference between root and user**: Could indicate:
+- BTRFS encoded write optimization not being triggered
+- burst-downloader not attempting to use `BTRFS_IOC_ENCODED_WRITE`
+- Loop device overhead dominating for small archives where the optimization benefit is minimal
+
+## Running Your Own Tests
+
+For detailed instructions on running performance tests, including:
+- AWS resource setup
+- Archive generation
+- Workflow configuration
+- Manual testing
+
+See [tests/performance/README.md](../tests/performance/README.md).
+
+### Quick Start
+
+```bash
+# Trigger a performance test run via GitHub Actions
+gh workflow run performance-test.yaml \
+  -f branch_ref=main \
+  -f s3_results_prefix=perf-$(date +%Y%m%d) \
+  -f test_instance_types=i7ie.xlarge \
+  -f test_archives=verysmall,small,medium
+```
+
+### Downloading Results
+
+```bash
+# Download all results for a test run
+aws s3 sync s3://burst-performance-results/perf-20250108/ ./results/
+
+# View a specific result file
+cat results/i7ie.xlarge-setup_btrfs.csv
+```
+
+## Future Enhancements
+
+The performance testing framework is designed to be extended. Planned improvements include:
+
+- **Profiling mode**: Detailed syscall-level metrics using BURST's built-in profiling
+- **Comparison tests**: Benchmark alternative download tools using the individual files structure
+- **Instance storage testing**: Compare NVMe vs EBS performance
+- **Visualization**: Automated graph generation from CSV results
+- **Historical tracking**: Compare performance across git commits/releases

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -1,0 +1,289 @@
+# BURST Performance Testing Framework
+
+This directory contains the performance testing framework for benchmarking `burst-downloader` across different EC2 instance types, archive sizes, and filesystem configurations.
+
+## Overview
+
+The framework provisions EC2 spot instances, runs controlled download tests, collects timing metrics, and aggregates results to S3. Tests are run sequentially with cooldown periods to ensure S3 performance isolation between tests.
+
+## S3 Bucket Structure
+
+### Test Archives Bucket: `burst-performance-tests`
+
+```
+burst-performance-tests/
+├── perf-test-verysmall/
+│   ├── archive.zip          # BURST archive (~5 MiB)
+│   └── files/
+│       └── data.bin         # Individual files for comparison testing
+├── perf-test-small/
+│   ├── archive.zip          # BURST archive (~40 MiB)
+│   └── files/
+│       └── data.bin
+├── perf-test-medium/
+│   ├── archive.zip          # BURST archive (~250 MiB)
+│   └── files/
+│       └── data.bin
+├── perf-test-medium-manyfiles/
+│   ├── archive.zip          # BURST archive (~250 MiB, ~5000 files)
+│   └── files/
+│       └── dir_XXXX/file_XXXXXX.txt  # Preserves directory structure
+├── ... (large, xlarge, xxlarge variants)
+└── runs/                    # Temporary storage for test binaries/scripts
+```
+
+### Results Bucket: `burst-performance-results`
+
+```
+burst-performance-results/
+└── {prefix}/
+    ├── i7ie.xlarge-setup_btrfs_root.csv
+    ├── i7ie.xlarge-setup_btrfs_user.csv
+    ├── i7ie.3xlarge-setup_btrfs_root.csv
+    ├── i7ie.3xlarge-setup_btrfs_user.csv
+    └── ... (one CSV per instance type × init script combination)
+```
+
+## CSV Format
+
+```csv
+date,instance_type,init_script,archive_name,wall_time,user_cpu_time,system_cpu_time,max_memory_kb,exit_code
+2025-01-08T10:30:00Z,i7ie.xlarge,setup_btrfs_root,verysmall,0.523,0.142,0.089,45632,0
+```
+
+## Setup Instructions
+
+### 1. Create S3 Buckets
+
+Create the following S3 buckets in us-west-2:
+
+```bash
+aws s3 mb s3://burst-performance-tests --region us-west-2
+aws s3 mb s3://burst-performance-results --region us-west-2
+```
+
+### 2. Create IAM Resources
+
+#### EC2 Instance Profile
+
+Create an IAM role `BurstPerformanceTestInstance` with:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:GetObject"],
+      "Resource": "arn:aws:s3:::burst-performance-tests/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["s3:PutObject"],
+      "Resource": "arn:aws:s3:::burst-performance-results/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeTags"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ssm:UpdateInstanceInformation",
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+Create an instance profile with the same name and attach the role.
+
+#### Security Group
+
+Create security group `burst-perf-test-sg` with:
+- Outbound: Allow all HTTPS (port 443) for S3 and SSM
+- Inbound: None required (SSM uses outbound-only connections)
+
+### 3. Generate Test Archives
+
+Build burst-writer and run the archive creation script:
+
+```bash
+cd build && make burst-writer
+cd ..
+./tests/performance/create_perf_test_archives.sh
+```
+
+To create specific archives only:
+
+```bash
+./tests/performance/create_perf_test_archives.sh verysmall small medium
+```
+
+**Note**: Large archives (xlarge, xxlarge) require significant disk space and time to generate.
+
+### 4. Configure GitHub Actions
+
+The workflow uses the IAM role `arn:aws:iam::339404546440:role/BurstPerformanceTests` via OIDC authentication. Ensure this role has permissions for:
+
+- EC2: `RunInstances`, `TerminateInstances`, `DescribeInstances`, `DescribeInstanceStatus`
+- IAM: `PassRole` (to attach instance profile to EC2)
+- SSM: `SendCommand`, `GetCommandInvocation`
+- S3: `GetObject`, `PutObject`, `ListBucket` on both buckets
+
+## Running Tests
+
+### Via GitHub Actions (Recommended)
+
+Trigger the workflow manually from the Actions tab:
+
+```bash
+gh workflow run performance-test.yaml \
+  -f branch_ref=main \
+  -f s3_results_prefix=perf-run-$(date +%Y%m%d) \
+  -f test_instance_types=i7ie.xlarge,m6id.4xlarge \
+  -f test_archives=verysmall,small,medium
+```
+
+### Workflow Inputs
+
+| Input | Description | Default |
+|-------|-------------|---------|
+| `branch_ref` | Branch or ref to build from | `main` |
+| `s3_results_prefix` | S3 prefix for results | (required) |
+| `test_instance_types` | Comma-separated instance types | `i7ie.xlarge,i7ie.3xlarge,i7ie.12xlarge,m6id.4xlarge` |
+| `test_init_scripts` | Comma-separated init scripts | `setup_btrfs_root.sh,setup_btrfs_user.sh` |
+| `test_archives` | Comma-separated archive names | All archives |
+| `cooldown_minutes` | Cooldown between instance types | `45` |
+
+### Manual Testing
+
+For debugging, you can run the orchestration script directly:
+
+```bash
+export AWS_REGION=us-west-2
+
+./tests/performance/run_perf_test_on_ec2.sh \
+  --instance-type t3.medium \
+  --init-script setup_btrfs_user.sh \
+  --archives verysmall \
+  --binary-path ./build/burst-downloader \
+  --results-prefix test-manual-$(date +%s)
+```
+
+## Test Matrix
+
+### Instance Types
+
+| Type | vCPUs | Memory | Network | Notes |
+|------|-------|--------|---------|-------|
+| i7ie.xlarge | 4 | 32 GiB | up to 25 Gbps | Storage-optimized, NVMe SSD |
+| i7ie.3xlarge | 12 | 96 GiB | up to 25 Gbps | Storage-optimized, NVMe SSD |
+| i7ie.12xlarge | 48 | 384 GiB | 75 Gbps | Storage-optimized, NVMe SSD |
+| m6id.4xlarge | 16 | 64 GiB | up to 12.5 Gbps | General purpose with NVMe |
+
+### Initialization Scripts
+
+| Script | Description |
+|--------|-------------|
+| `setup_btrfs_root.sh` | BTRFS with zstd compression, runs burst-downloader as root (enables `BTRFS_IOC_ENCODED_WRITE`) |
+| `setup_btrfs_user.sh` | BTRFS with zstd compression, runs burst-downloader as regular user (disables `BTRFS_IOC_ENCODED_WRITE`) |
+
+### Archive Sizes
+
+| Name | Size | Files | Notes |
+|------|------|-------|-------|
+| verysmall | ~5 MiB | 1 | Single BURST part |
+| small | ~40 MiB | 1 | Multiple parts |
+| medium | ~250 MiB | 1 | Single large file |
+| medium-manyfiles | ~250 MiB | ~5000 | Many small files |
+| large | ~1 GiB | 1 | Single large file |
+| large-manyfiles | ~1 GiB | ~10000 | Many small files |
+| xlarge | ~10 GiB | 1 | Single large file |
+| xlarge-manyfiles | ~10 GiB | ~25000 | Many small files |
+| xxlarge | ~50 GiB | 1 | Single large file |
+
+## Results Interpretation
+
+### Expected Performance Characteristics
+
+- **BTRFS as root** should show lowest wall time due to BTRFS_IOC_ENCODED_WRITE zero-copy optimization
+- **BTRFS as user** provides baseline showing standard write performance without the encoded write optimization
+- The difference between these configurations isolates the benefit of `BTRFS_IOC_ENCODED_WRITE`
+
+### Analyzing Results
+
+Download results from S3:
+
+```bash
+aws s3 sync s3://burst-performance-results/your-prefix/ ./results/
+```
+
+Combine and analyze with Python:
+
+```python
+import pandas as pd
+import glob
+
+# Load all CSVs
+dfs = [pd.read_csv(f) for f in glob.glob('results/*.csv')]
+df = pd.concat(dfs, ignore_index=True)
+
+# Summary by instance type and init script
+summary = df.groupby(['instance_type', 'init_script', 'archive_name']).agg({
+    'wall_time': ['mean', 'std'],
+    'exit_code': 'sum'
+})
+print(summary)
+```
+
+## Troubleshooting
+
+### Instance Fails to Start
+
+1. Check CloudWatch Logs for user-data script output
+2. Verify IAM instance profile exists and has correct permissions
+3. Ensure security group allows outbound HTTPS
+
+### Tests Timeout
+
+1. Check if spot instance was interrupted (view spot request history)
+2. Increase timeout in SSM command
+3. Test with smaller archives first
+
+### Results Not Uploaded
+
+1. Instance may have terminated before upload completed
+2. Check S3 bucket permissions
+3. Review instance logs in `/var/log/burst-perf-*.log`
+
+### Spot Instance Interruptions
+
+The framework handles interruptions gracefully:
+- Instance has `instance-initiated-shutdown-behavior: terminate`
+- Orchestration script includes cleanup trap
+- Failed tests can be retried with the retry step
+
+## Cost Estimation
+
+Per full test run (4 instance types × 2 init scripts × 9 archives):
+
+| Component | Estimated Cost |
+|-----------|----------------|
+| i7ie.xlarge spot (~1h) | ~$0.07 |
+| i7ie.3xlarge spot (~1h) | ~$0.21 |
+| i7ie.12xlarge spot (~1h) | ~$0.84 |
+| m6id.4xlarge spot (~1h) | ~$0.23 |
+| S3 requests (~500 GETs) | ~$0.002 |
+| Data transfer (in-region) | $0 |
+| **Total** | **~$3-5** |
+
+Note: Spot prices vary by availability zone and time.

--- a/tests/performance/aggregate_results.sh
+++ b/tests/performance/aggregate_results.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+#
+# Aggregate Results Script for BURST Performance Tests
+#
+# This script parses /usr/bin/time output and formats it as CSV.
+# It can be sourced by ec2_run_tests.sh or used standalone.
+#
+# Functions:
+#   parse_time_output <time_output_file> - Parse /usr/bin/time output
+#   format_csv_row <params...>           - Format a CSV row
+#   write_csv_header <csv_file>          - Write CSV header
+#   append_csv_row <csv_file> <params..> - Append a row to CSV
+#
+
+# Parse /usr/bin/time output with format "wall=%e user=%U sys=%S maxrss=%M"
+# Usage: parse_time_output <time_output_file>
+# Sets: WALL_TIME, USER_TIME, SYS_TIME, MAX_RSS
+parse_time_output() {
+    local time_file="$1"
+
+    # Initialize defaults
+    WALL_TIME="0"
+    USER_TIME="0"
+    SYS_TIME="0"
+    MAX_RSS="0"
+
+    if [ ! -f "$time_file" ]; then
+        echo "Warning: Time output file not found: $time_file" >&2
+        return 1
+    fi
+
+    # Look for PERF_METRICS line in the output
+    local metrics_line
+    metrics_line=$(grep "PERF_METRICS:" "$time_file" 2>/dev/null | tail -1)
+
+    if [ -z "$metrics_line" ]; then
+        echo "Warning: No PERF_METRICS found in $time_file" >&2
+        return 1
+    fi
+
+    # Parse the metrics
+    # Format: "PERF_METRICS: wall=1.23 user=0.45 sys=0.12 maxrss=12345"
+    WALL_TIME=$(echo "$metrics_line" | grep -oP 'wall=\K[0-9.]+' || echo "0")
+    USER_TIME=$(echo "$metrics_line" | grep -oP 'user=\K[0-9.]+' || echo "0")
+    SYS_TIME=$(echo "$metrics_line" | grep -oP 'sys=\K[0-9.]+' || echo "0")
+    MAX_RSS=$(echo "$metrics_line" | grep -oP 'maxrss=\K[0-9]+' || echo "0")
+
+    return 0
+}
+
+# Write CSV header
+# Usage: write_csv_header <csv_file>
+write_csv_header() {
+    local csv_file="$1"
+    echo "date,instance_type,init_script,archive_name,wall_time,user_cpu_time,system_cpu_time,max_memory_kb,exit_code" > "$csv_file"
+}
+
+# Format a CSV row
+# Usage: format_csv_row <date> <instance_type> <init_script> <archive_name> <wall_time> <user_time> <sys_time> <max_rss> <exit_code>
+# Returns: CSV-formatted row
+format_csv_row() {
+    local date="$1"
+    local instance_type="$2"
+    local init_script="$3"
+    local archive_name="$4"
+    local wall_time="$5"
+    local user_time="$6"
+    local sys_time="$7"
+    local max_rss="$8"
+    local exit_code="$9"
+
+    echo "$date,$instance_type,$init_script,$archive_name,$wall_time,$user_time,$sys_time,$max_rss,$exit_code"
+}
+
+# Append a row to CSV file
+# Usage: append_csv_row <csv_file> <date> <instance_type> <init_script> <archive_name> <wall_time> <user_time> <sys_time> <max_rss> <exit_code>
+append_csv_row() {
+    local csv_file="$1"
+    shift
+    format_csv_row "$@" >> "$csv_file"
+}
+
+# Parse time output and append to CSV in one step
+# Usage: parse_and_append <time_output_file> <csv_file> <date> <instance_type> <init_script> <archive_name> <exit_code>
+parse_and_append() {
+    local time_file="$1"
+    local csv_file="$2"
+    local date="$3"
+    local instance_type="$4"
+    local init_script="$5"
+    local archive_name="$6"
+    local exit_code="$7"
+
+    if parse_time_output "$time_file"; then
+        append_csv_row "$csv_file" "$date" "$instance_type" "$init_script" "$archive_name" \
+            "$WALL_TIME" "$USER_TIME" "$SYS_TIME" "$MAX_RSS" "$exit_code"
+        return 0
+    else
+        # Still record the result even if parsing failed
+        append_csv_row "$csv_file" "$date" "$instance_type" "$init_script" "$archive_name" \
+            "0" "0" "0" "0" "$exit_code"
+        return 1
+    fi
+}
+
+# If run directly (not sourced), provide a simple CLI
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    case "$1" in
+        parse)
+            if [ -z "$2" ]; then
+                echo "Usage: $0 parse <time_output_file>"
+                exit 1
+            fi
+            if parse_time_output "$2"; then
+                echo "WALL_TIME=$WALL_TIME"
+                echo "USER_TIME=$USER_TIME"
+                echo "SYS_TIME=$SYS_TIME"
+                echo "MAX_RSS=$MAX_RSS"
+            else
+                exit 1
+            fi
+            ;;
+        header)
+            if [ -z "$2" ]; then
+                echo "Usage: $0 header <csv_file>"
+                exit 1
+            fi
+            write_csv_header "$2"
+            echo "Header written to $2"
+            ;;
+        *)
+            echo "Usage: $0 <command> [args...]"
+            echo ""
+            echo "Commands:"
+            echo "  parse <time_output_file>  - Parse time output and print values"
+            echo "  header <csv_file>         - Write CSV header to file"
+            echo ""
+            echo "This script can also be sourced to use its functions directly."
+            exit 1
+            ;;
+    esac
+fi

--- a/tests/performance/create_perf_test_archives.sh
+++ b/tests/performance/create_perf_test_archives.sh
@@ -21,6 +21,15 @@
 #   xlarge-manyfiles - 10 GiB (~25000 files)
 #   xxlarge       - 50 GiB (single large file)
 #
+# Content Generation:
+#   All content files are derived from a 200 MiB calibrated seed generated once
+#   at startup. The seed is built by interleaving 32 KiB blocks of shuffled
+#   dictionary words (compressible) and /dev/urandom (incompressible) at a
+#   ratio tuned so the resulting burst-writer archive is 45-65% of the logical
+#   size. Files <= 200 MiB take a random section of the seed; larger files
+#   concatenate seed copies. This ensures S3 download benchmarks reflect
+#   realistic data volumes.
+#
 # Usage:
 #   ./create_perf_test_archives.sh [archive_name...]
 #
@@ -31,6 +40,7 @@
 #   - burst-writer built in build/
 #   - aws CLI configured with appropriate credentials
 #   - 7zz installed for archive validation
+#   - /usr/share/dict/words for compressible content generation
 #
 # Environment variables:
 #   BURST_PERF_BUCKET  - S3 bucket for test archives (default: burst-performance-tests)
@@ -81,7 +91,7 @@ declare -A ARCHIVE_CONFIGS=(
     ["large"]="1073741824:single:1"            # 1 GiB
     ["large-manyfiles"]="1073741824:many:10000"
     ["xlarge"]="10737418240:single:1"          # 10 GiB
-    ["xlarge-manyfiles"]="10737418240:many:250000"
+    ["xlarge-manyfiles"]="10737418240:many:25000"
     ["xxlarge"]="53687091200:single:1"         # 50 GiB
 )
 
@@ -119,6 +129,12 @@ check_prerequisites() {
         missing=1
     fi
 
+    if [ ! -s /usr/share/dict/words ]; then
+        echo -e "${RED}Error: /usr/share/dict/words not found or empty${NC}"
+        echo "  Required for generating compressible content"
+        missing=1
+    fi
+
     if [ $missing -eq 1 ]; then
         return 1
     fi
@@ -127,109 +143,140 @@ check_prerequisites() {
     return 0
 }
 
-# Create semi-compressible data file
-# Uses a mix of random and repeated data to achieve moderate compression
-# Optimized: generates seed pool then copies data to reach target size
-# Usage: create_semi_compressible_file <filename> <size_bytes>
-create_semi_compressible_file() {
-    local filename="$1"
-    local target_size="$2"
-
-    echo "  Creating semi-compressible file ($((target_size / 1024 / 1024)) MiB)..."
-
-    local block_size=$((1024 * 1024))  # 1 MiB blocks
-
-    # Determine seed pool size (100 MiB for files > 500 MiB, otherwise 20% of target)
-    local seed_size
-    if [ "$target_size" -gt 524288000 ]; then
-        seed_size=$((100 * 1024 * 1024))  # 100 MiB seed for large files
-    else
-        seed_size=$((target_size / 5))  # 20% for smaller files
-        if [ "$seed_size" -lt $((10 * 1024 * 1024)) ]; then
-            seed_size=$((10 * 1024 * 1024))  # Minimum 10 MiB seed
-        fi
-        if [ "$seed_size" -gt "$target_size" ]; then
-            seed_size="$target_size"
-        fi
-    fi
-
-    local seed_blocks=$((seed_size / block_size))
-
-    echo "  Generating seed pool ($((seed_size / 1024 / 1024)) MiB)..."
-
-    # Create the file and generate seed pool
-    > "$filename"
-
-    for ((i = 0; i < seed_blocks; i++)); do
-        # Alternate between random and semi-predictable data
-        if ((i % 4 == 0)); then
-            # Every 4th block is random
-            dd if=/dev/urandom bs="$block_size" count=1 2>/dev/null >> "$filename"
-        else
-            # Other blocks are semi-compressible (repeated patterns with variation)
-            dd if=/dev/urandom bs=256 count=1 2>/dev/null | \
-                head -c 256 | \
-                perl -e 'my $p = <STDIN>; print $p x 4096;' | \
-                head -c "$block_size" >> "$filename"
-        fi
+# Generate 200 MiB blob of shuffled dictionary words
+# Output written to $DICT_BLOB
+generate_dict_blob() {
+    local target_size=$((200 * 1024 * 1024))
+    echo "Generating 200 MiB dictionary word blob..."
+    > "$DICT_BLOB"
+    while [ "$(stat -c%s "$DICT_BLOB")" -lt "$target_size" ]; do
+        shuf /usr/share/dict/words | tr '\n' ' ' >> "$DICT_BLOB"
     done
-
-    local current_size
-    current_size=$(stat -c%s "$filename")
-
-    # If target size is larger than seed, replicate data by copying from file itself
-    if [ "$current_size" -lt "$target_size" ]; then
-        echo "  Extending file by copying seed data..."
-
-        while [ "$current_size" -lt "$target_size" ]; do
-            local remaining=$((target_size - current_size))
-            local copy_size="$current_size"
-
-            # Don't copy more than we need
-            if [ "$copy_size" -gt "$remaining" ]; then
-                copy_size="$remaining"
-            fi
-
-            # Copy data from beginning of file to end
-            dd if="$filename" bs="$block_size" count=$((copy_size / block_size)) 2>/dev/null >> "$filename"
-
-            # Handle any remaining bytes
-            local copied_bytes=$((copy_size / block_size * block_size))
-            if [ "$copied_bytes" -lt "$copy_size" ]; then
-                dd if="$filename" bs=1 skip="$copied_bytes" count=$((copy_size - copied_bytes)) 2>/dev/null >> "$filename"
-            fi
-
-            current_size=$(stat -c%s "$filename")
-
-            # Progress report for large files
-            if [ "$target_size" -gt 1073741824 ]; then
-                echo "    Progress: $((current_size / 1024 / 1024)) / $((target_size / 1024 / 1024)) MiB"
-            fi
-        done
-    fi
-
-    # Ensure exact size
-    truncate -s "$target_size" "$filename"
-
-    local actual_size
-    actual_size=$(stat -c%s "$filename")
-    echo "  Created file: $((actual_size / 1024 / 1024)) MiB"
+    truncate -s "$target_size" "$DICT_BLOB"
+    echo "  Done: $(( $(stat -c%s "$DICT_BLOB") / 1024 / 1024 )) MiB"
 }
 
-# Create compressible file using dictionary words
-# Usage: create_compressible_file <filename> <size_bytes>
-create_compressible_file() {
+# Generate a mixed-content file by interleaving 32 KiB dict and random blocks
+# Usage: generate_mixed_file <filename> <size_bytes> <dict_pct>
+#   dict_pct: integer 0-100, percentage of blocks sourced from DICT_BLOB
+generate_mixed_file() {
     local filename="$1"
-    local target_size="$2"
+    local size_bytes="$2"
+    local dict_pct="$3"
+
+    local block_size=32768  # 32 KiB
+    local num_blocks=$(( size_bytes / block_size ))
+    local dict_total_blocks=$(( 200 * 1024 * 1024 / block_size ))  # 6400 blocks
+    local dict_idx=0
 
     > "$filename"
-    while [ "$(stat -c%s "$filename")" -lt "$target_size" ]; do
-        local words
-        words=$(shuf -n 100 /usr/share/dict/words 2>/dev/null) || \
-            words="Lorem ipsum dolor sit amet consectetur adipiscing elit"
-        printf '%s ' $words >> "$filename"
+
+    for (( i = 0; i < num_blocks; i++ )); do
+        if (( RANDOM % 100 < dict_pct )); then
+            dd if="$DICT_BLOB" bs="$block_size" skip="$dict_idx" count=1 2>/dev/null >> "$filename"
+            dict_idx=$(( (dict_idx + 1) % dict_total_blocks ))
+        else
+            dd if=/dev/urandom bs="$block_size" count=1 2>/dev/null >> "$filename"
+        fi
     done
-    truncate -s "$target_size" "$filename"
+
+    truncate -s "$size_bytes" "$filename"
+}
+
+# Run burst-writer on a file and return archive_size * 100 / input_size
+# Usage: ratio=$(measure_burst_compression_ratio <file>)
+measure_burst_compression_ratio() {
+    local input_file="$1"
+    local input_size
+    input_size=$(stat -c%s "$input_file")
+
+    local measure_dir="$TEMP_DIR/measure_$$"
+    local measure_input="$measure_dir/input"
+    local measure_archive="$measure_dir/archive.zip"
+    mkdir -p "$measure_input"
+
+    ln "$input_file" "$measure_input/data.bin"
+    "$BURST_WRITER" -l 3 -o "$measure_archive" "$measure_input" 2>/dev/null
+
+    local archive_size
+    archive_size=$(stat -c%s "$measure_archive")
+
+    rm -rf "$measure_dir"
+
+    echo $(( archive_size * 100 / input_size ))
+}
+
+# Calibrate CALIBRATED_SEED by adjusting CALIBRATED_DICT_PCT until burst-writer
+# produces an archive that is 45-65% of the input size.
+calibrate_seed() {
+    local seed_size=$((200 * 1024 * 1024))
+    echo "Calibrating seed for target compression ratio (45-65%)..."
+
+    for (( attempt = 0; attempt < 8; attempt++ )); do
+        echo "  Attempt $((attempt + 1)): dict_pct=$CALIBRATED_DICT_PCT"
+        echo "  Generating 200 MiB mixed seed..."
+        generate_mixed_file "$CALIBRATED_SEED" "$seed_size" "$CALIBRATED_DICT_PCT"
+
+        echo "  Measuring compression ratio..."
+        local ratio
+        ratio=$(measure_burst_compression_ratio "$CALIBRATED_SEED")
+        echo "  Compression ratio: ${ratio}% (archive/input)"
+
+        if (( ratio >= 45 && ratio <= 65 )); then
+            echo -e "${GREEN}  Calibration successful: ratio=${ratio}%, dict_pct=${CALIBRATED_DICT_PCT}${NC}"
+            return 0
+        elif (( ratio < 45 )); then
+            # Too compressible — reduce dict content, add more random data
+            CALIBRATED_DICT_PCT=$(( CALIBRATED_DICT_PCT - 15 ))
+        else
+            # Not compressible enough — add more dict content
+            CALIBRATED_DICT_PCT=$(( CALIBRATED_DICT_PCT + 15 ))
+        fi
+
+        # Clamp to [5, 95]
+        if (( CALIBRATED_DICT_PCT < 5 )); then
+            CALIBRATED_DICT_PCT=5
+        fi
+        if (( CALIBRATED_DICT_PCT > 95 )); then
+            CALIBRATED_DICT_PCT=95
+        fi
+    done
+
+    echo -e "${YELLOW}Warning: Could not achieve 45-65% ratio after 8 attempts. Using dict_pct=${CALIBRATED_DICT_PCT}${NC}"
+}
+
+# Create a content file derived from the calibrated seed
+# Files <= 200 MiB: extract a random 512-byte-aligned section
+# Files > 200 MiB: concatenate seed copies + partial remainder
+# Usage: create_content_file <filename> <size_bytes>
+create_content_file() {
+    local filename="$1"
+    local size_bytes="$2"
+
+    local seed_size=$((200 * 1024 * 1024))
+
+    if (( size_bytes <= seed_size )); then
+        local max_offset=$(( seed_size - size_bytes ))
+        local offset=0
+        if (( max_offset > 512 )); then
+            local max_offset_blocks=$(( max_offset / 512 ))
+            offset=$(( (RANDOM * 32768 + RANDOM) % max_offset_blocks * 512 ))
+        fi
+        dd if="$CALIBRATED_SEED" iflag=skip_bytes,count_bytes \
+            skip="$offset" count="$size_bytes" bs=65536 of="$filename" 2>/dev/null
+    else
+        > "$filename"
+        local written=0
+        while (( written + seed_size <= size_bytes )); do
+            cat "$CALIBRATED_SEED" >> "$filename"
+            written=$(( written + seed_size ))
+        done
+        local remaining=$(( size_bytes - written ))
+        if (( remaining > 0 )); then
+            head -c "$remaining" "$CALIBRATED_SEED" >> "$filename"
+        fi
+        truncate -s "$size_bytes" "$filename"
+    fi
 }
 
 # Generate random lowercase string
@@ -262,7 +309,9 @@ create_single_file_archive() {
     mkdir -p "$input_dir"
 
     # Create single large file
-    create_semi_compressible_file "$input_dir/data.bin" "$target_size"
+    echo "  Creating content file ($((target_size / 1024 / 1024)) MiB)..."
+    create_content_file "$input_dir/data.bin" "$target_size"
+    echo "  Created file: $(($(stat -c%s "$input_dir/data.bin") / 1024 / 1024)) MiB"
 
     # Create BURST archive
     echo "Creating BURST archive..."
@@ -304,7 +353,7 @@ create_single_file_archive() {
 }
 
 # Create many-files archive
-# Optimized: creates template files and hardlinks them to reduce generation time
+# Each file is generated from a unique section of the calibrated seed.
 # Usage: create_many_files_archive <name> <target_size_bytes> <file_count>
 create_many_files_archive() {
     local name="$1"
@@ -316,49 +365,14 @@ create_many_files_archive() {
 
     local work_dir="$TEMP_DIR/$name"
     local input_dir="$work_dir/input"
-    local template_dir="$work_dir/templates"
     local archive_file="$work_dir/archive.zip"
 
     mkdir -p "$input_dir"
-    mkdir -p "$template_dir"
 
     # Calculate target file size (with some variation)
     local avg_file_size=$((target_size / file_count))
     local min_file_size=$((avg_file_size / 2))
     local max_file_size=$((avg_file_size * 3 / 2))
-
-    # Determine number of template files to create
-    # Use 1-2% of total files as templates, minimum 50, maximum 500
-    local template_count=$((file_count / 75))
-    if [ "$template_count" -lt 50 ]; then
-        template_count=50
-    fi
-    if [ "$template_count" -gt 500 ]; then
-        template_count=500
-    fi
-    if [ "$template_count" -gt "$file_count" ]; then
-        template_count="$file_count"
-    fi
-
-    echo "Creating $template_count template files (will hardlink to create $file_count total files)..."
-
-    # Create template files
-    local templates=()
-    for ((i = 0; i < template_count; i++)); do
-        local file_size=$(random_size "$min_file_size" "$max_file_size")
-        local template_file="$template_dir/template_$(printf "%04d" "$i").txt"
-
-        create_compressible_file "$template_file" "$file_size"
-        templates+=("$template_file")
-
-        # Progress every 50 templates
-        if (( i > 0 && i % 50 == 0 )); then
-            echo "  Progress: $i/$template_count templates created..."
-        fi
-    done
-
-    echo -e "${GREEN}Created $template_count template files${NC}"
-    echo "Creating hardlinks to generate $file_count files..."
 
     # Distribute files across subdirectories (100 files per directory)
     local files_per_dir=100
@@ -366,21 +380,19 @@ create_many_files_archive() {
     local created=0
     local total_size=0
 
+    echo "Creating $file_count content files (avg $((avg_file_size / 1024)) KiB each)..."
+
     for ((dir_idx = 0; dir_idx < num_dirs; dir_idx++)); do
         local subdir="$input_dir/dir_$(printf "%04d" "$dir_idx")"
         mkdir -p "$subdir"
 
         for ((file_idx = 0; file_idx < files_per_dir && created < file_count; file_idx++)); do
-            local filename="$subdir/file_$(printf "%06d" "$created").txt"
-
-            # Randomly select a template to hardlink
-            local template_idx=$((RANDOM % template_count))
-            local template_file="${templates[$template_idx]}"
-
-            ln "$template_file" "$filename"
-
+            local filename="$subdir/file_$(printf "%06d" "$created").bin"
             local file_size
-            file_size=$(stat -c%s "$filename")
+            file_size=$(random_size "$min_file_size" "$max_file_size")
+
+            create_content_file "$filename" "$file_size"
+
             total_size=$((total_size + file_size))
             created=$((created + 1))
         done
@@ -392,9 +404,6 @@ create_many_files_archive() {
     done
 
     echo -e "${GREEN}Created $created files ($((total_size / 1024 / 1024)) MiB uncompressed)${NC}"
-
-    # Clean up template directory
-    rm -rf "$template_dir"
 
     # Create BURST archive
     echo "Creating BURST archive..."
@@ -504,6 +513,11 @@ echo ""
 TEMP_DIR=$(mktemp -d)
 echo "Working directory: $TEMP_DIR"
 
+# Global paths for calibrated content generation
+DICT_BLOB="$TEMP_DIR/dict_blob.bin"
+CALIBRATED_SEED="$TEMP_DIR/calibrated_seed.bin"
+CALIBRATED_DICT_PCT=50
+
 # Cleanup on exit
 cleanup() {
     echo ""
@@ -512,6 +526,13 @@ cleanup() {
     echo -e "${GREEN}Cleanup complete${NC}"
 }
 trap cleanup EXIT
+
+# Generate calibrated seed once before creating any archives
+echo ""
+echo -e "${BLUE}--- Generating calibrated content seed ---${NC}"
+generate_dict_blob
+calibrate_seed
+echo ""
 
 # Create archives
 for name in "${archives_to_create[@]}"; do

--- a/tests/performance/create_perf_test_archives.sh
+++ b/tests/performance/create_perf_test_archives.sh
@@ -1,0 +1,533 @@
+#!/bin/bash
+#
+# Create performance test archives for BURST benchmarking
+#
+# Creates test archives at various sizes and uploads them to S3.
+# Each archive is uploaded both as a complete ZIP and as individual files
+# to enable future comparison testing with non-BURST tools.
+#
+# S3 Layout:
+#   perf-test-{size}/archive.zip       - The BURST archive
+#   perf-test-{size}/files/*           - Individual files (preserving structure)
+#
+# Archive sizes:
+#   verysmall     - 5-6 MiB (single part)
+#   small         - 40 MiB
+#   medium        - 250 MiB (single large file)
+#   medium-manyfiles - 250 MiB (~5000 files)
+#   large         - 1 GiB (single large file)
+#   large-manyfiles  - 1 GiB (~10000 files)
+#   xlarge        - 10 GiB (single large file)
+#   xlarge-manyfiles - 10 GiB (~25000 files)
+#   xxlarge       - 50 GiB (single large file)
+#
+# Usage:
+#   ./create_perf_test_archives.sh [archive_name...]
+#
+#   If no archive names are specified, all archives are created.
+#   Specify one or more names to create only those archives.
+#
+# Prerequisites:
+#   - burst-writer built in build/
+#   - aws CLI configured with appropriate credentials
+#   - 7zz installed for archive validation
+#
+# Environment variables:
+#   BURST_PERF_BUCKET  - S3 bucket for test archives (default: burst-performance-tests)
+#   AWS_REGION         - AWS region (default: us-west-2)
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BUILD_DIR="$PROJECT_ROOT/build"
+BURST_WRITER="$BUILD_DIR/burst-writer"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Load configuration from .env if present
+if [ -f "$PROJECT_ROOT/.env" ]; then
+    echo "Loading configuration from .env..."
+    # shellcheck source=/dev/null
+    source "$PROJECT_ROOT/.env"
+fi
+
+# Set defaults
+: "${BURST_PERF_BUCKET:=burst-performance-tests}"
+: "${AWS_REGION:=us-west-2}"
+
+echo ""
+echo -e "${BLUE}============================================${NC}"
+echo -e "${BLUE}BURST Performance Test Archive Creation${NC}"
+echo -e "${BLUE}============================================${NC}"
+echo ""
+echo "Configuration:"
+echo "  S3 Bucket: $BURST_PERF_BUCKET"
+echo "  AWS Region: $AWS_REGION"
+echo ""
+
+# Archive configurations: name, target_size_bytes, type (single|many), file_count (for many)
+declare -A ARCHIVE_CONFIGS=(
+    ["verysmall"]="5242880:single:1"           # 5 MiB
+    ["small"]="41943040:single:1"              # 40 MiB
+    ["medium"]="262144000:single:1"            # 250 MiB
+    ["medium-manyfiles"]="262144000:many:5000"
+    ["large"]="1073741824:single:1"            # 1 GiB
+    ["large-manyfiles"]="1073741824:many:10000"
+    ["xlarge"]="10737418240:single:1"          # 10 GiB
+    ["xlarge-manyfiles"]="10737418240:many:250000"
+    ["xxlarge"]="53687091200:single:1"         # 50 GiB
+)
+
+# All archive names in order
+ALL_ARCHIVES=(
+    "verysmall"
+    "small"
+    "medium"
+    "medium-manyfiles"
+    "large"
+    "large-manyfiles"
+    "xlarge"
+    "xlarge-manyfiles"
+    "xxlarge"
+)
+
+# Check prerequisites
+check_prerequisites() {
+    local missing=0
+
+    if [ ! -f "$BURST_WRITER" ]; then
+        echo -e "${RED}Error: burst-writer not found at $BURST_WRITER${NC}"
+        echo "  Run: cd $BUILD_DIR && make burst-writer"
+        missing=1
+    fi
+
+    if ! command -v aws &> /dev/null; then
+        echo -e "${RED}Error: aws CLI not found${NC}"
+        missing=1
+    fi
+
+    if ! command -v 7zz &> /dev/null; then
+        echo -e "${RED}Error: 7zz not found${NC}"
+        echo "  Required for archive validation"
+        missing=1
+    fi
+
+    if [ $missing -eq 1 ]; then
+        return 1
+    fi
+
+    echo -e "${GREEN}All prerequisites met${NC}"
+    return 0
+}
+
+# Create semi-compressible data file
+# Uses a mix of random and repeated data to achieve moderate compression
+# Optimized: generates seed pool then copies data to reach target size
+# Usage: create_semi_compressible_file <filename> <size_bytes>
+create_semi_compressible_file() {
+    local filename="$1"
+    local target_size="$2"
+
+    echo "  Creating semi-compressible file ($((target_size / 1024 / 1024)) MiB)..."
+
+    local block_size=$((1024 * 1024))  # 1 MiB blocks
+
+    # Determine seed pool size (100 MiB for files > 500 MiB, otherwise 20% of target)
+    local seed_size
+    if [ "$target_size" -gt 524288000 ]; then
+        seed_size=$((100 * 1024 * 1024))  # 100 MiB seed for large files
+    else
+        seed_size=$((target_size / 5))  # 20% for smaller files
+        if [ "$seed_size" -lt $((10 * 1024 * 1024)) ]; then
+            seed_size=$((10 * 1024 * 1024))  # Minimum 10 MiB seed
+        fi
+        if [ "$seed_size" -gt "$target_size" ]; then
+            seed_size="$target_size"
+        fi
+    fi
+
+    local seed_blocks=$((seed_size / block_size))
+
+    echo "  Generating seed pool ($((seed_size / 1024 / 1024)) MiB)..."
+
+    # Create the file and generate seed pool
+    > "$filename"
+
+    for ((i = 0; i < seed_blocks; i++)); do
+        # Alternate between random and semi-predictable data
+        if ((i % 4 == 0)); then
+            # Every 4th block is random
+            dd if=/dev/urandom bs="$block_size" count=1 2>/dev/null >> "$filename"
+        else
+            # Other blocks are semi-compressible (repeated patterns with variation)
+            dd if=/dev/urandom bs=256 count=1 2>/dev/null | \
+                head -c 256 | \
+                perl -e 'my $p = <STDIN>; print $p x 4096;' | \
+                head -c "$block_size" >> "$filename"
+        fi
+    done
+
+    local current_size
+    current_size=$(stat -c%s "$filename")
+
+    # If target size is larger than seed, replicate data by copying from file itself
+    if [ "$current_size" -lt "$target_size" ]; then
+        echo "  Extending file by copying seed data..."
+
+        while [ "$current_size" -lt "$target_size" ]; do
+            local remaining=$((target_size - current_size))
+            local copy_size="$current_size"
+
+            # Don't copy more than we need
+            if [ "$copy_size" -gt "$remaining" ]; then
+                copy_size="$remaining"
+            fi
+
+            # Copy data from beginning of file to end
+            dd if="$filename" bs="$block_size" count=$((copy_size / block_size)) 2>/dev/null >> "$filename"
+
+            # Handle any remaining bytes
+            local copied_bytes=$((copy_size / block_size * block_size))
+            if [ "$copied_bytes" -lt "$copy_size" ]; then
+                dd if="$filename" bs=1 skip="$copied_bytes" count=$((copy_size - copied_bytes)) 2>/dev/null >> "$filename"
+            fi
+
+            current_size=$(stat -c%s "$filename")
+
+            # Progress report for large files
+            if [ "$target_size" -gt 1073741824 ]; then
+                echo "    Progress: $((current_size / 1024 / 1024)) / $((target_size / 1024 / 1024)) MiB"
+            fi
+        done
+    fi
+
+    # Ensure exact size
+    truncate -s "$target_size" "$filename"
+
+    local actual_size
+    actual_size=$(stat -c%s "$filename")
+    echo "  Created file: $((actual_size / 1024 / 1024)) MiB"
+}
+
+# Create compressible file using dictionary words
+# Usage: create_compressible_file <filename> <size_bytes>
+create_compressible_file() {
+    local filename="$1"
+    local target_size="$2"
+
+    > "$filename"
+    while [ "$(stat -c%s "$filename")" -lt "$target_size" ]; do
+        shuf -n 100 /usr/share/dict/words 2>/dev/null | tr '\n' ' ' >> "$filename" || \
+        echo "Lorem ipsum dolor sit amet consectetur adipiscing elit " >> "$filename"
+    done
+    truncate -s "$target_size" "$filename"
+}
+
+# Generate random lowercase string
+random_string() {
+    local length="$1"
+    tr -dc 'a-z' < /dev/urandom | head -c "$length"
+}
+
+# Generate random size between min and max
+# Usage: random_size <min_bytes> <max_bytes>
+random_size() {
+    local min="$1"
+    local max="$2"
+    echo $(( (RANDOM * 32768 + RANDOM) % (max - min) + min ))
+}
+
+# Create single-file archive
+# Usage: create_single_file_archive <name> <target_size_bytes>
+create_single_file_archive() {
+    local name="$1"
+    local target_size="$2"
+
+    echo ""
+    echo -e "${BLUE}--- Creating $name archive (single file, $((target_size / 1024 / 1024)) MiB) ---${NC}"
+
+    local work_dir="$TEMP_DIR/$name"
+    local input_dir="$work_dir/input"
+    local archive_file="$work_dir/archive.zip"
+
+    mkdir -p "$input_dir"
+
+    # Create single large file
+    create_semi_compressible_file "$input_dir/data.bin" "$target_size"
+
+    # Create BURST archive
+    echo "Creating BURST archive..."
+    "$BURST_WRITER" -l 3 -o "$archive_file" "$input_dir"
+
+    local archive_size
+    archive_size=$(stat -c%s "$archive_file")
+    local part_count=$(( (archive_size + 8388607) / 8388608 ))
+    echo -e "${GREEN}Created archive: $((archive_size / 1024 / 1024)) MiB ($part_count parts)${NC}"
+
+    # Verify archive with 7zz
+    echo "Verifying archive..."
+    if ! 7zz t "$archive_file" 2>&1 | grep -q "Everything is Ok"; then
+        echo -e "${RED}Archive validation failed${NC}"
+        7zz t "$archive_file"
+        return 1
+    fi
+    echo -e "${GREEN}Archive validation passed${NC}"
+
+    # Upload archive to S3
+    echo "Uploading archive to S3..."
+    if ! aws s3 cp "$archive_file" "s3://$BURST_PERF_BUCKET/perf-test-$name/archive.zip" \
+        --region "$AWS_REGION" >/dev/null; then
+        echo -e "${RED}Failed to upload archive${NC}"
+        return 1
+    fi
+    echo -e "${GREEN}Uploaded s3://$BURST_PERF_BUCKET/perf-test-$name/archive.zip${NC}"
+
+    # Upload individual files to S3 (preserving structure)
+    echo "Uploading individual files to S3..."
+    if ! aws s3 sync "$input_dir" "s3://$BURST_PERF_BUCKET/perf-test-$name/files/" \
+        --region "$AWS_REGION" >/dev/null; then
+        echo -e "${RED}Failed to upload individual files${NC}"
+        return 1
+    fi
+    echo -e "${GREEN}Uploaded individual files to s3://$BURST_PERF_BUCKET/perf-test-$name/files/${NC}"
+
+    echo -e "${GREEN}$name archive complete${NC}"
+}
+
+# Create many-files archive
+# Optimized: creates template files and hardlinks them to reduce generation time
+# Usage: create_many_files_archive <name> <target_size_bytes> <file_count>
+create_many_files_archive() {
+    local name="$1"
+    local target_size="$2"
+    local file_count="$3"
+
+    echo ""
+    echo -e "${BLUE}--- Creating $name archive ($file_count files, ~$((target_size / 1024 / 1024)) MiB) ---${NC}"
+
+    local work_dir="$TEMP_DIR/$name"
+    local input_dir="$work_dir/input"
+    local template_dir="$work_dir/templates"
+    local archive_file="$work_dir/archive.zip"
+
+    mkdir -p "$input_dir"
+    mkdir -p "$template_dir"
+
+    # Calculate target file size (with some variation)
+    local avg_file_size=$((target_size / file_count))
+    local min_file_size=$((avg_file_size / 2))
+    local max_file_size=$((avg_file_size * 3 / 2))
+
+    # Determine number of template files to create
+    # Use 1-2% of total files as templates, minimum 50, maximum 500
+    local template_count=$((file_count / 75))
+    if [ "$template_count" -lt 50 ]; then
+        template_count=50
+    fi
+    if [ "$template_count" -gt 500 ]; then
+        template_count=500
+    fi
+    if [ "$template_count" -gt "$file_count" ]; then
+        template_count="$file_count"
+    fi
+
+    echo "Creating $template_count template files (will hardlink to create $file_count total files)..."
+
+    # Create template files
+    local templates=()
+    for ((i = 0; i < template_count; i++)); do
+        local file_size=$(random_size "$min_file_size" "$max_file_size")
+        local template_file="$template_dir/template_$(printf "%04d" "$i").txt"
+
+        create_compressible_file "$template_file" "$file_size"
+        templates+=("$template_file")
+
+        # Progress every 50 templates
+        if (( i > 0 && i % 50 == 0 )); then
+            echo "  Progress: $i/$template_count templates created..."
+        fi
+    done
+
+    echo -e "${GREEN}Created $template_count template files${NC}"
+    echo "Creating hardlinks to generate $file_count files..."
+
+    # Distribute files across subdirectories (100 files per directory)
+    local files_per_dir=100
+    local num_dirs=$(( (file_count + files_per_dir - 1) / files_per_dir ))
+    local created=0
+    local total_size=0
+
+    for ((dir_idx = 0; dir_idx < num_dirs; dir_idx++)); do
+        local subdir="$input_dir/dir_$(printf "%04d" "$dir_idx")"
+        mkdir -p "$subdir"
+
+        for ((file_idx = 0; file_idx < files_per_dir && created < file_count; file_idx++)); do
+            local filename="$subdir/file_$(printf "%06d" "$created").txt"
+
+            # Randomly select a template to hardlink
+            local template_idx=$((RANDOM % template_count))
+            local template_file="${templates[$template_idx]}"
+
+            ln "$template_file" "$filename"
+
+            local file_size
+            file_size=$(stat -c%s "$filename")
+            total_size=$((total_size + file_size))
+            created=$((created + 1))
+        done
+
+        # Progress every 50 directories
+        if (( (dir_idx + 1) % 50 == 0 )); then
+            echo "  Progress: $created/$file_count files created ($((total_size / 1024 / 1024)) MiB)..."
+        fi
+    done
+
+    echo -e "${GREEN}Created $created files ($((total_size / 1024 / 1024)) MiB uncompressed)${NC}"
+
+    # Clean up template directory
+    rm -rf "$template_dir"
+
+    # Create BURST archive
+    echo "Creating BURST archive..."
+    "$BURST_WRITER" -l 3 -o "$archive_file" "$input_dir"
+
+    local archive_size
+    archive_size=$(stat -c%s "$archive_file")
+    local part_count=$(( (archive_size + 8388607) / 8388608 ))
+    echo -e "${GREEN}Created archive: $((archive_size / 1024 / 1024)) MiB ($part_count parts)${NC}"
+
+    # Verify archive with 7zz
+    echo "Verifying archive..."
+    if ! 7zz t "$archive_file" 2>&1 | grep -q "Everything is Ok"; then
+        echo -e "${RED}Archive validation failed${NC}"
+        7zz t "$archive_file"
+        return 1
+    fi
+    echo -e "${GREEN}Archive validation passed${NC}"
+
+    # Upload archive to S3
+    echo "Uploading archive to S3..."
+    if ! aws s3 cp "$archive_file" "s3://$BURST_PERF_BUCKET/perf-test-$name/archive.zip" \
+        --region "$AWS_REGION" >/dev/null; then
+        echo -e "${RED}Failed to upload archive${NC}"
+        return 1
+    fi
+    echo -e "${GREEN}Uploaded s3://$BURST_PERF_BUCKET/perf-test-$name/archive.zip${NC}"
+
+    # Upload individual files to S3 (preserving structure)
+    echo "Uploading individual files to S3 (this may take a while for many files)..."
+    if ! aws s3 sync "$input_dir" "s3://$BURST_PERF_BUCKET/perf-test-$name/files/" \
+        --region "$AWS_REGION" >/dev/null; then
+        echo -e "${RED}Failed to upload individual files${NC}"
+        return 1
+    fi
+    echo -e "${GREEN}Uploaded individual files to s3://$BURST_PERF_BUCKET/perf-test-$name/files/${NC}"
+
+    echo -e "${GREEN}$name archive complete${NC}"
+}
+
+# Create archive based on configuration
+# Usage: create_archive <name>
+create_archive() {
+    local name="$1"
+    local config="${ARCHIVE_CONFIGS[$name]}"
+
+    if [ -z "$config" ]; then
+        echo -e "${RED}Unknown archive: $name${NC}"
+        return 1
+    fi
+
+    IFS=':' read -r target_size type file_count <<< "$config"
+
+    if [ "$type" = "single" ]; then
+        create_single_file_archive "$name" "$target_size"
+    else
+        create_many_files_archive "$name" "$target_size" "$file_count"
+    fi
+}
+
+# Print usage
+print_usage() {
+    echo "Usage: $0 [archive_name...]"
+    echo ""
+    echo "Available archives:"
+    for name in "${ALL_ARCHIVES[@]}"; do
+        local config="${ARCHIVE_CONFIGS[$name]}"
+        IFS=':' read -r size type count <<< "$config"
+        local size_mb=$((size / 1024 / 1024))
+        if [ "$type" = "single" ]; then
+            echo "  $name - ${size_mb} MiB (single file)"
+        else
+            echo "  $name - ${size_mb} MiB (~$count files)"
+        fi
+    done
+    echo ""
+    echo "If no archive names are specified, all archives are created."
+}
+
+# Main execution
+if ! check_prerequisites; then
+    exit 1
+fi
+
+# Parse arguments
+archives_to_create=()
+if [ $# -eq 0 ]; then
+    archives_to_create=("${ALL_ARCHIVES[@]}")
+elif [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+    print_usage
+    exit 0
+else
+    for arg in "$@"; do
+        if [ -z "${ARCHIVE_CONFIGS[$arg]}" ]; then
+            echo -e "${RED}Unknown archive: $arg${NC}"
+            print_usage
+            exit 1
+        fi
+        archives_to_create+=("$arg")
+    done
+fi
+
+echo "Archives to create: ${archives_to_create[*]}"
+echo ""
+
+# Create temporary working directory
+TEMP_DIR=$(mktemp -d)
+echo "Working directory: $TEMP_DIR"
+
+# Cleanup on exit
+cleanup() {
+    echo ""
+    echo "Cleaning up temporary files..."
+    rm -rf "$TEMP_DIR"
+    echo -e "${GREEN}Cleanup complete${NC}"
+}
+trap cleanup EXIT
+
+# Create archives
+for name in "${archives_to_create[@]}"; do
+    create_archive "$name"
+
+    # Clean up intermediate files after each archive to save disk space
+    rm -rf "${TEMP_DIR:?}/$name"
+done
+
+# Print summary
+echo ""
+echo -e "${BLUE}============================================${NC}"
+echo -e "${GREEN}Performance Test Archives Created${NC}"
+echo -e "${BLUE}============================================${NC}"
+echo ""
+echo "Archives available at s3://$BURST_PERF_BUCKET/"
+for name in "${archives_to_create[@]}"; do
+    echo "  perf-test-$name/archive.zip"
+    echo "  perf-test-$name/files/"
+done
+echo ""

--- a/tests/performance/create_perf_test_archives.sh
+++ b/tests/performance/create_perf_test_archives.sh
@@ -91,7 +91,7 @@ declare -A ARCHIVE_CONFIGS=(
     ["large"]="1073741824:single:1"            # 1 GiB
     ["large-manyfiles"]="1073741824:many:10000"
     ["xlarge"]="10737418240:single:1"          # 10 GiB
-    ["xlarge-manyfiles"]="10737418240:many:25000"
+    ["xlarge-manyfiles"]="10737418240:many:300000"
     ["xxlarge"]="53687091200:single:1"         # 50 GiB
 )
 

--- a/tests/performance/create_perf_test_archives.sh
+++ b/tests/performance/create_perf_test_archives.sh
@@ -224,8 +224,10 @@ create_compressible_file() {
 
     > "$filename"
     while [ "$(stat -c%s "$filename")" -lt "$target_size" ]; do
-        shuf -n 100 /usr/share/dict/words 2>/dev/null | tr '\n' ' ' >> "$filename" || \
-        echo "Lorem ipsum dolor sit amet consectetur adipiscing elit " >> "$filename"
+        local words
+        words=$(shuf -n 100 /usr/share/dict/words 2>/dev/null) || \
+            words="Lorem ipsum dolor sit amet consectetur adipiscing elit"
+        printf '%s ' $words >> "$filename"
     done
     truncate -s "$target_size" "$filename"
 }

--- a/tests/performance/create_perf_test_archives.sh
+++ b/tests/performance/create_perf_test_archives.sh
@@ -196,7 +196,7 @@ measure_burst_compression_ratio() {
     mkdir -p "$measure_input"
 
     ln "$input_file" "$measure_input/data.bin"
-    "$BURST_WRITER" -l 3 -o "$measure_archive" "$measure_input" 2>/dev/null
+    "$BURST_WRITER" -l 3 -o "$measure_archive" "$measure_input" &>/dev/null
 
     local archive_size
     archive_size=$(stat -c%s "$measure_archive")

--- a/tests/performance/ec2_bootstrap.sh
+++ b/tests/performance/ec2_bootstrap.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+#
+# EC2 Bootstrap Script for BURST Performance Tests
+#
+# This script runs as user-data when the EC2 instance starts.
+# It prepares the instance environment for running performance tests.
+#
+# The script:
+#   1. Installs required dependencies (libzstd, awscli, time)
+#   2. Creates the performance test directory structure
+#   3. Downloads the burst-downloader binary from S3
+#   4. Downloads test scripts from S3
+#   5. Signals readiness via SSM parameter
+#
+# On failure, the instance will self-terminate via shutdown.
+#
+# Environment variables (passed via instance tags or SSM):
+#   BURST_BINARY_S3_PATH   - S3 path to burst-downloader binary
+#   BURST_SCRIPTS_S3_PATH  - S3 path to test scripts tarball
+#   BURST_RESULTS_PREFIX   - S3 prefix for results
+#   AWS_REGION             - AWS region for S3 operations
+#
+
+set -e
+
+LOG_FILE="/var/log/burst-perf-bootstrap.log"
+PERF_DIR="/opt/burst-perf"
+
+# Redirect all output to log file
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+echo "=========================================="
+echo "BURST Performance Test Bootstrap"
+echo "Started at: $(date -Iseconds)"
+echo "=========================================="
+
+# Error handler - shutdown on failure
+error_handler() {
+    local exit_code=$?
+    local line_number=$1
+    echo ""
+    echo "ERROR: Bootstrap failed at line $line_number with exit code $exit_code"
+    echo "Initiating instance shutdown..."
+    echo "Bootstrap failed at $(date -Iseconds)" >> "$LOG_FILE"
+
+    # Give time for logs to flush
+    sync
+    sleep 5
+
+    # Shutdown the instance (will terminate due to instance-initiated-shutdown-behavior)
+    sudo shutdown -h now
+}
+
+trap 'error_handler $LINENO' ERR
+
+# Get instance metadata
+echo "Fetching instance metadata..."
+TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" 2>/dev/null)
+INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id 2>/dev/null)
+INSTANCE_TYPE=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-type 2>/dev/null)
+AVAILABILITY_ZONE=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/placement/availability-zone 2>/dev/null)
+
+echo "Instance ID: $INSTANCE_ID"
+echo "Instance Type: $INSTANCE_TYPE"
+echo "Availability Zone: $AVAILABILITY_ZONE"
+
+# Get configuration from instance tags
+echo ""
+echo "Fetching instance tags..."
+
+# Wait for IAM role to be available
+for i in {1..30}; do
+    if aws sts get-caller-identity --region us-west-2 >/dev/null 2>&1; then
+        break
+    fi
+    echo "Waiting for IAM role... ($i/30)"
+    sleep 2
+done
+
+# Fetch tags
+BURST_BINARY_S3_PATH=$(aws ec2 describe-tags \
+    --filters "Name=resource-id,Values=$INSTANCE_ID" "Name=key,Values=BurstBinaryS3Path" \
+    --query 'Tags[0].Value' --output text --region us-west-2 2>/dev/null || echo "")
+
+BURST_SCRIPTS_S3_PATH=$(aws ec2 describe-tags \
+    --filters "Name=resource-id,Values=$INSTANCE_ID" "Name=key,Values=BurstScriptsS3Path" \
+    --query 'Tags[0].Value' --output text --region us-west-2 2>/dev/null || echo "")
+
+BURST_RESULTS_PREFIX=$(aws ec2 describe-tags \
+    --filters "Name=resource-id,Values=$INSTANCE_ID" "Name=key,Values=BurstResultsPrefix" \
+    --query 'Tags[0].Value' --output text --region us-west-2 2>/dev/null || echo "")
+
+BURST_INIT_SCRIPT=$(aws ec2 describe-tags \
+    --filters "Name=resource-id,Values=$INSTANCE_ID" "Name=key,Values=BurstInitScript" \
+    --query 'Tags[0].Value' --output text --region us-west-2 2>/dev/null || echo "")
+
+BURST_TEST_ARCHIVES=$(aws ec2 describe-tags \
+    --filters "Name=resource-id,Values=$INSTANCE_ID" "Name=key,Values=BurstTestArchives" \
+    --query 'Tags[0].Value' --output text --region us-west-2 2>/dev/null || echo "")
+
+echo "Binary S3 Path: $BURST_BINARY_S3_PATH"
+echo "Scripts S3 Path: $BURST_SCRIPTS_S3_PATH"
+echo "Results Prefix: $BURST_RESULTS_PREFIX"
+echo "Init Script: $BURST_INIT_SCRIPT"
+echo "Test Archives: $BURST_TEST_ARCHIVES"
+
+# Validate required tags
+if [ -z "$BURST_BINARY_S3_PATH" ] || [ "$BURST_BINARY_S3_PATH" = "None" ]; then
+    echo "ERROR: BurstBinaryS3Path tag not set"
+    exit 1
+fi
+
+if [ -z "$BURST_SCRIPTS_S3_PATH" ] || [ "$BURST_SCRIPTS_S3_PATH" = "None" ]; then
+    echo "ERROR: BurstScriptsS3Path tag not set"
+    exit 1
+fi
+
+# Install dependencies
+echo ""
+echo "Installing dependencies..."
+
+# Update package list
+sudo apt-get update -qq
+
+# Install required packages
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+    libzstd1 \
+    awscli \
+    time \
+    btrfs-progs \
+    jq
+
+echo "Dependencies installed successfully"
+
+# Create directory structure
+echo ""
+echo "Creating directory structure..."
+sudo mkdir -p "$PERF_DIR"/{bin,scripts,results,output}
+sudo chown -R ubuntu:ubuntu "$PERF_DIR"
+
+# Download burst-downloader binary
+echo ""
+echo "Downloading burst-downloader binary..."
+aws s3 cp "$BURST_BINARY_S3_PATH" "$PERF_DIR/bin/burst-downloader" --region us-west-2
+chmod +x "$PERF_DIR/bin/burst-downloader"
+echo "Binary downloaded: $PERF_DIR/bin/burst-downloader"
+
+# Verify binary works
+if ! "$PERF_DIR/bin/burst-downloader" --help >/dev/null 2>&1; then
+    echo "ERROR: burst-downloader binary verification failed"
+    exit 1
+fi
+echo "Binary verification passed"
+
+# Download test scripts
+echo ""
+echo "Downloading test scripts..."
+aws s3 cp "$BURST_SCRIPTS_S3_PATH" "$PERF_DIR/scripts/scripts.tar.gz" --region us-west-2
+tar -xzf "$PERF_DIR/scripts/scripts.tar.gz" -C "$PERF_DIR/scripts/"
+rm "$PERF_DIR/scripts/scripts.tar.gz"
+chmod +x "$PERF_DIR/scripts/"*.sh 2>/dev/null || true
+chmod +x "$PERF_DIR/scripts/init_scripts/"*.sh 2>/dev/null || true
+echo "Scripts downloaded to $PERF_DIR/scripts/"
+
+# Save configuration for test runner
+echo ""
+echo "Saving configuration..."
+cat > "$PERF_DIR/config.env" << EOF
+INSTANCE_ID=$INSTANCE_ID
+INSTANCE_TYPE=$INSTANCE_TYPE
+AVAILABILITY_ZONE=$AVAILABILITY_ZONE
+BURST_RESULTS_PREFIX=$BURST_RESULTS_PREFIX
+BURST_INIT_SCRIPT=$BURST_INIT_SCRIPT
+BURST_TEST_ARCHIVES=$BURST_TEST_ARCHIVES
+AWS_REGION=us-west-2
+BURST_BINARY=$PERF_DIR/bin/burst-downloader
+PERF_DIR=$PERF_DIR
+EOF
+
+echo "Configuration saved to $PERF_DIR/config.env"
+
+# Mark bootstrap as complete
+echo ""
+echo "=========================================="
+echo "Bootstrap complete at: $(date -Iseconds)"
+echo "=========================================="
+echo ""
+echo "Ready to run performance tests."
+echo "Run: $PERF_DIR/scripts/ec2_run_tests.sh"
+
+# Create completion marker
+touch "$PERF_DIR/.bootstrap_complete"

--- a/tests/performance/ec2_run_tests.sh
+++ b/tests/performance/ec2_run_tests.sh
@@ -1,0 +1,252 @@
+#!/bin/bash
+#
+# EC2 Test Runner Script for BURST Performance Tests
+#
+# This script runs on the EC2 instance and executes all performance tests.
+# It is called after ec2_bootstrap.sh completes.
+#
+# The script:
+#   1. Loads configuration from /opt/burst-perf/config.env
+#   2. Runs the specified initialization script (setup_baseline.sh, setup_btrfs.sh, etc.)
+#   3. For each archive, runs burst-downloader with /usr/bin/time
+#   4. Collects metrics and appends to CSV file
+#   5. Uploads results to S3
+#   6. Shuts down the instance on completion or error
+#
+# Usage:
+#   ./ec2_run_tests.sh
+#
+# The script expects the following files to exist:
+#   /opt/burst-perf/config.env           - Configuration from bootstrap
+#   /opt/burst-perf/bin/burst-downloader - The binary to test
+#   /opt/burst-perf/scripts/init_scripts/ - Initialization scripts
+#
+
+set -e
+
+PERF_DIR="/opt/burst-perf"
+LOG_FILE="/var/log/burst-perf-tests.log"
+SCRIPTS_DIR="$PERF_DIR/scripts"
+
+# Redirect all output to log file
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+echo "=========================================="
+echo "BURST Performance Test Runner"
+echo "Started at: $(date -Iseconds)"
+echo "=========================================="
+
+# Error handler - shutdown on failure
+error_handler() {
+    local exit_code=$?
+    local line_number=$1
+    echo ""
+    echo "ERROR: Test runner failed at line $line_number with exit code $exit_code"
+    echo "Test runner failed at $(date -Iseconds)" >> "$LOG_FILE"
+
+    # Give time for logs to flush
+    sync
+    sleep 5
+
+    # Shutdown the instance
+    echo "Initiating instance shutdown..."
+    sudo shutdown -h now
+}
+
+trap 'error_handler $LINENO' ERR
+
+# Load configuration
+if [ ! -f "$PERF_DIR/config.env" ]; then
+    echo "ERROR: Configuration file not found: $PERF_DIR/config.env"
+    exit 1
+fi
+
+# shellcheck source=/dev/null
+source "$PERF_DIR/config.env"
+
+# Source aggregate_results.sh for CSV functions
+# shellcheck source=/dev/null
+source "$SCRIPTS_DIR/aggregate_results.sh"
+
+echo ""
+echo "Configuration:"
+echo "  Instance ID: $INSTANCE_ID"
+echo "  Instance Type: $INSTANCE_TYPE"
+echo "  Init Script: $BURST_INIT_SCRIPT"
+echo "  Test Archives: $BURST_TEST_ARCHIVES"
+echo "  Results Prefix: $BURST_RESULTS_PREFIX"
+echo ""
+
+# Validate configuration
+if [ -z "$BURST_INIT_SCRIPT" ]; then
+    echo "ERROR: BURST_INIT_SCRIPT not set"
+    exit 1
+fi
+
+if [ -z "$BURST_TEST_ARCHIVES" ]; then
+    echo "ERROR: BURST_TEST_ARCHIVES not set"
+    exit 1
+fi
+
+if [ -z "$BURST_RESULTS_PREFIX" ]; then
+    echo "ERROR: BURST_RESULTS_PREFIX not set"
+    exit 1
+fi
+
+# Parse test archives (comma-separated)
+IFS=',' read -ra ARCHIVES <<< "$BURST_TEST_ARCHIVES"
+
+echo "Archives to test: ${ARCHIVES[*]}"
+echo ""
+
+# Run initialization script
+echo "=========================================="
+echo "Running initialization script: $BURST_INIT_SCRIPT"
+echo "=========================================="
+
+INIT_SCRIPT_PATH="$SCRIPTS_DIR/init_scripts/$BURST_INIT_SCRIPT"
+if [ ! -f "$INIT_SCRIPT_PATH" ]; then
+    echo "ERROR: Init script not found: $INIT_SCRIPT_PATH"
+    exit 1
+fi
+
+# Source the init script to get BURST_OUTPUT_DIR
+# shellcheck source=/dev/null
+source "$INIT_SCRIPT_PATH"
+
+if [ -z "$BURST_OUTPUT_DIR" ]; then
+    echo "ERROR: Init script did not set BURST_OUTPUT_DIR"
+    exit 1
+fi
+
+echo ""
+echo "Init script complete. Output directory: $BURST_OUTPUT_DIR"
+echo ""
+
+# Initialize CSV file
+CSV_FILE="$PERF_DIR/results/${INSTANCE_TYPE}-${BURST_INIT_SCRIPT%.sh}.csv"
+write_csv_header "$CSV_FILE"
+echo "Results will be written to: $CSV_FILE"
+echo ""
+
+# Run tests for each archive
+TOTAL_TESTS=${#ARCHIVES[@]}
+COMPLETED=0
+FAILED=0
+
+echo "=========================================="
+echo "Running performance tests"
+echo "=========================================="
+
+for archive_name in "${ARCHIVES[@]}"; do
+    COMPLETED=$((COMPLETED + 1))
+    echo ""
+    echo "[$COMPLETED/$TOTAL_TESTS] Testing archive: $archive_name"
+    echo "-------------------------------------------"
+
+    # Create output directory for this test
+    TEST_OUTPUT_DIR="$BURST_OUTPUT_DIR/test-$archive_name-$(date +%s)"
+    mkdir -p "$TEST_OUTPUT_DIR"
+
+    # Prepare time output file
+    TIME_OUTPUT="/tmp/burst-time-$archive_name.txt"
+
+    # Record test start time
+    TEST_DATE=$(date -Iseconds)
+
+    # Run burst-downloader with /usr/bin/time
+    # If BURST_RUN_AS_ROOT is set, run as root to enable BTRFS_IOC_ENCODED_WRITE
+    echo "Starting download at $TEST_DATE..."
+    EXIT_CODE=0
+
+    if [ "${BURST_RUN_AS_ROOT:-0}" = "1" ]; then
+        echo "Running as root (enables BTRFS_IOC_ENCODED_WRITE)..."
+        sudo /usr/bin/time -f "PERF_METRICS: wall=%e user=%U sys=%S maxrss=%M" \
+            "$BURST_BINARY" \
+                --bucket burst-performance-tests \
+                --key "perf-test-$archive_name/archive.zip" \
+                --region us-west-2 \
+                --output-dir "$TEST_OUTPUT_DIR" \
+                --part-size 8 \
+                --max-concurrent-parts 8 \
+            2>&1 | tee "$TIME_OUTPUT" || EXIT_CODE=$?
+    else
+        echo "Running as regular user (BTRFS_IOC_ENCODED_WRITE disabled)..."
+        /usr/bin/time -f "PERF_METRICS: wall=%e user=%U sys=%S maxrss=%M" \
+            "$BURST_BINARY" \
+                --bucket burst-performance-tests \
+                --key "perf-test-$archive_name/archive.zip" \
+                --region us-west-2 \
+                --output-dir "$TEST_OUTPUT_DIR" \
+                --part-size 8 \
+                --max-concurrent-parts 8 \
+            2>&1 | tee "$TIME_OUTPUT" || EXIT_CODE=$?
+    fi
+
+    echo ""
+    if [ $EXIT_CODE -eq 0 ]; then
+        echo "Download completed successfully"
+    else
+        echo "Download failed with exit code: $EXIT_CODE"
+        FAILED=$((FAILED + 1))
+    fi
+
+    # Parse time output and append to CSV
+    if parse_and_append "$TIME_OUTPUT" "$CSV_FILE" "$TEST_DATE" "$INSTANCE_TYPE" \
+        "${BURST_INIT_SCRIPT%.sh}" "$archive_name" "$EXIT_CODE"; then
+        echo "Metrics recorded to CSV"
+    else
+        echo "Warning: Failed to parse metrics, recorded with zeros"
+    fi
+
+    # Clean up test output to free disk space
+    echo "Cleaning up test output..."
+    rm -rf "$TEST_OUTPUT_DIR"
+    rm -f "$TIME_OUTPUT"
+
+    echo "-------------------------------------------"
+done
+
+echo ""
+echo "=========================================="
+echo "Test Summary"
+echo "=========================================="
+echo "Total tests: $TOTAL_TESTS"
+echo "Completed: $COMPLETED"
+echo "Failed: $FAILED"
+echo ""
+
+# Display CSV contents
+echo "Results CSV:"
+cat "$CSV_FILE"
+echo ""
+
+# Upload results to S3
+echo "=========================================="
+echo "Uploading results to S3"
+echo "=========================================="
+
+S3_RESULTS_PATH="s3://burst-performance-results/$BURST_RESULTS_PREFIX/${INSTANCE_TYPE}-${BURST_INIT_SCRIPT%.sh}.csv"
+echo "Uploading to: $S3_RESULTS_PATH"
+
+if aws s3 cp "$CSV_FILE" "$S3_RESULTS_PATH" --region us-west-2; then
+    echo "Results uploaded successfully"
+else
+    echo "ERROR: Failed to upload results"
+    exit 1
+fi
+
+echo ""
+echo "=========================================="
+echo "Performance tests complete"
+echo "Completed at: $(date -Iseconds)"
+echo "=========================================="
+
+# Give time for logs to flush
+sync
+sleep 5
+
+# Shutdown the instance
+echo ""
+echo "Initiating instance shutdown..."
+sudo shutdown -h now

--- a/tests/performance/init_scripts/setup_btrfs_root.sh
+++ b/tests/performance/init_scripts/setup_btrfs_root.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+#
+# BTRFS initialization script for BURST performance tests (root user)
+#
+# This script creates a BTRFS filesystem with zstd compression enabled,
+# and configures the test to run burst-downloader as root.
+#
+# Running as root allows burst-downloader to use BTRFS_IOC_ENCODED_WRITE,
+# which enables zero-copy passthrough of compressed data directly to disk.
+#
+# When sourced, this script exports:
+#   BURST_OUTPUT_DIR   - Directory for burst-downloader output
+#   BTRFS_LOOP_DEVICE  - The loop device path
+#   BTRFS_LOOP_IMAGE   - Path to the loop device image file
+#   BURST_RUN_AS_ROOT  - Flag indicating burst-downloader should run as root
+#
+# Usage:
+#   source setup_btrfs_root.sh
+#
+
+set -e
+
+echo "=== BTRFS Setup (root user) ==="
+
+# Configuration
+BTRFS_SIZE_GB=100
+BTRFS_MOUNT_DIR="/mnt/burst-perf-btrfs-root"
+BTRFS_LOOP_IMAGE="/tmp/btrfs-perf-root.img"
+
+# Check if BTRFS is already mounted
+if mountpoint -q "$BTRFS_MOUNT_DIR" 2>/dev/null; then
+    fstype=$(stat -f -c %T "$BTRFS_MOUNT_DIR" 2>/dev/null || echo "unknown")
+    if [ "$fstype" = "btrfs" ]; then
+        echo "BTRFS already mounted at $BTRFS_MOUNT_DIR"
+        BURST_OUTPUT_DIR="$BTRFS_MOUNT_DIR"
+        export BURST_OUTPUT_DIR
+        export BURST_RUN_AS_ROOT=1
+        return 0 2>/dev/null || exit 0
+    fi
+fi
+
+# Clean up any previous setup
+if [ -f "$BTRFS_LOOP_IMAGE" ]; then
+    # Find and detach any loop device using this image
+    EXISTING_LOOP=$(losetup -j "$BTRFS_LOOP_IMAGE" | cut -d: -f1 || true)
+    if [ -n "$EXISTING_LOOP" ]; then
+        echo "Detaching existing loop device: $EXISTING_LOOP"
+        sudo umount "$BTRFS_MOUNT_DIR" 2>/dev/null || true
+        sudo losetup -d "$EXISTING_LOOP" 2>/dev/null || true
+    fi
+    rm -f "$BTRFS_LOOP_IMAGE"
+fi
+
+# Create sparse file for loop device
+echo "Creating ${BTRFS_SIZE_GB} GiB sparse image file..."
+dd if=/dev/zero of="$BTRFS_LOOP_IMAGE" bs=1M count=0 seek=$((BTRFS_SIZE_GB * 1024)) 2>/dev/null
+
+# Set up loop device
+echo "Setting up loop device..."
+BTRFS_LOOP_DEVICE=$(sudo losetup -f --show "$BTRFS_LOOP_IMAGE")
+echo "Loop device: $BTRFS_LOOP_DEVICE"
+
+# Create BTRFS filesystem
+echo "Creating BTRFS filesystem..."
+sudo mkfs.btrfs -f -L "burst-perf-root" "$BTRFS_LOOP_DEVICE" >/dev/null 2>&1
+
+# Create mount point
+sudo mkdir -p "$BTRFS_MOUNT_DIR"
+
+# Mount with zstd compression
+echo "Mounting BTRFS with zstd compression..."
+sudo mount -o compress=zstd "$BTRFS_LOOP_DEVICE" "$BTRFS_MOUNT_DIR"
+
+# Keep ownership as root since burst-downloader will run as root
+echo "Note: Directory owned by root (burst-downloader will run as root)"
+
+# Show filesystem info
+echo ""
+echo "Filesystem information:"
+df -h "$BTRFS_MOUNT_DIR"
+echo ""
+echo "BTRFS mount options:"
+mount | grep "$BTRFS_MOUNT_DIR"
+
+BURST_OUTPUT_DIR="$BTRFS_MOUNT_DIR"
+
+echo ""
+echo "BTRFS setup complete (root user mode)."
+echo "Output directory: $BURST_OUTPUT_DIR"
+echo "Loop device: $BTRFS_LOOP_DEVICE"
+echo "burst-downloader will run as root (enables BTRFS_IOC_ENCODED_WRITE)"
+
+# Export for use by caller
+export BURST_OUTPUT_DIR
+export BTRFS_LOOP_DEVICE
+export BTRFS_LOOP_IMAGE
+export BURST_RUN_AS_ROOT=1

--- a/tests/performance/init_scripts/setup_btrfs_user.sh
+++ b/tests/performance/init_scripts/setup_btrfs_user.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+#
+# BTRFS initialization script for BURST performance tests (regular user)
+#
+# This script creates a BTRFS filesystem with zstd compression enabled,
+# and configures the test to run burst-downloader as a regular user.
+#
+# Running as a regular user prevents burst-downloader from using
+# BTRFS_IOC_ENCODED_WRITE, which requires elevated privileges.
+# This tests standard file write performance on BTRFS.
+#
+# When sourced, this script exports:
+#   BURST_OUTPUT_DIR   - Directory for burst-downloader output
+#   BTRFS_LOOP_DEVICE  - The loop device path
+#   BTRFS_LOOP_IMAGE   - Path to the loop device image file
+#
+# Usage:
+#   source setup_btrfs_user.sh
+#
+
+set -e
+
+echo "=== BTRFS Setup (regular user) ==="
+
+# Configuration
+BTRFS_SIZE_GB=100
+BTRFS_MOUNT_DIR="/mnt/burst-perf-btrfs-user"
+BTRFS_LOOP_IMAGE="/tmp/btrfs-perf-user.img"
+
+# Check if BTRFS is already mounted
+if mountpoint -q "$BTRFS_MOUNT_DIR" 2>/dev/null; then
+    fstype=$(stat -f -c %T "$BTRFS_MOUNT_DIR" 2>/dev/null || echo "unknown")
+    if [ "$fstype" = "btrfs" ]; then
+        echo "BTRFS already mounted at $BTRFS_MOUNT_DIR"
+        BURST_OUTPUT_DIR="$BTRFS_MOUNT_DIR"
+        export BURST_OUTPUT_DIR
+        return 0 2>/dev/null || exit 0
+    fi
+fi
+
+# Clean up any previous setup
+if [ -f "$BTRFS_LOOP_IMAGE" ]; then
+    # Find and detach any loop device using this image
+    EXISTING_LOOP=$(losetup -j "$BTRFS_LOOP_IMAGE" | cut -d: -f1 || true)
+    if [ -n "$EXISTING_LOOP" ]; then
+        echo "Detaching existing loop device: $EXISTING_LOOP"
+        sudo umount "$BTRFS_MOUNT_DIR" 2>/dev/null || true
+        sudo losetup -d "$EXISTING_LOOP" 2>/dev/null || true
+    fi
+    rm -f "$BTRFS_LOOP_IMAGE"
+fi
+
+# Create sparse file for loop device
+echo "Creating ${BTRFS_SIZE_GB} GiB sparse image file..."
+dd if=/dev/zero of="$BTRFS_LOOP_IMAGE" bs=1M count=0 seek=$((BTRFS_SIZE_GB * 1024)) 2>/dev/null
+
+# Set up loop device
+echo "Setting up loop device..."
+BTRFS_LOOP_DEVICE=$(sudo losetup -f --show "$BTRFS_LOOP_IMAGE")
+echo "Loop device: $BTRFS_LOOP_DEVICE"
+
+# Create BTRFS filesystem
+echo "Creating BTRFS filesystem..."
+sudo mkfs.btrfs -f -L "burst-perf-user" "$BTRFS_LOOP_DEVICE" >/dev/null 2>&1
+
+# Create mount point
+sudo mkdir -p "$BTRFS_MOUNT_DIR"
+
+# Mount with zstd compression
+echo "Mounting BTRFS with zstd compression..."
+sudo mount -o compress=zstd "$BTRFS_LOOP_DEVICE" "$BTRFS_MOUNT_DIR"
+
+# Change ownership to ubuntu user
+sudo chown -R ubuntu:ubuntu "$BTRFS_MOUNT_DIR"
+
+# Show filesystem info
+echo ""
+echo "Filesystem information:"
+df -h "$BTRFS_MOUNT_DIR"
+echo ""
+echo "BTRFS mount options:"
+mount | grep "$BTRFS_MOUNT_DIR"
+
+BURST_OUTPUT_DIR="$BTRFS_MOUNT_DIR"
+
+echo ""
+echo "BTRFS setup complete (regular user mode)."
+echo "Output directory: $BURST_OUTPUT_DIR"
+echo "Loop device: $BTRFS_LOOP_DEVICE"
+echo "burst-downloader will run as regular user (BTRFS_IOC_ENCODED_WRITE disabled)"
+
+# Export for use by caller
+export BURST_OUTPUT_DIR
+export BTRFS_LOOP_DEVICE
+export BTRFS_LOOP_IMAGE

--- a/tests/performance/run_perf_test_on_ec2.sh
+++ b/tests/performance/run_perf_test_on_ec2.sh
@@ -1,0 +1,380 @@
+#!/bin/bash
+#
+# EC2 Performance Test Orchestration Script
+#
+# This script runs from GitHub Actions to provision an EC2 instance,
+# run performance tests, and clean up afterwards.
+#
+# The script:
+#   1. Creates a tarball of test scripts
+#   2. Uploads the binary and scripts to S3
+#   3. Provisions an EC2 spot instance with specific tags
+#   4. Waits for the instance to complete bootstrap
+#   5. Triggers test execution via SSM
+#   6. Waits for tests to complete
+#   7. Terminates the instance
+#
+# Usage:
+#   ./run_perf_test_on_ec2.sh \
+#       --instance-type <type> \
+#       --init-script <script.sh> \
+#       --archives <archive1,archive2,...> \
+#       --binary-path <path/to/burst-downloader> \
+#       --results-prefix <s3-prefix>
+#
+# Required environment variables:
+#   AWS_REGION - AWS region (default: us-west-2)
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Default configuration
+AWS_REGION="${AWS_REGION:-us-west-2}"
+PERF_BUCKET="burst-performance-tests"
+RESULTS_BUCKET="burst-performance-results"
+
+# Ubuntu 24.04 LTS AMI in us-west-2 (update as needed)
+# This is the official Canonical Ubuntu 24.04 LTS AMI
+UBUNTU_AMI="ami-0cf2b4e024cdb6960"
+
+# Instance profile name (must exist in AWS account)
+INSTANCE_PROFILE="BurstPerformanceTestInstance"
+
+# Security group (must exist in AWS account, needs outbound HTTPS)
+SECURITY_GROUP="burst-perf-test-sg"
+
+# Global variable for cleanup
+INSTANCE_ID=""
+
+# Cleanup function
+cleanup() {
+    local exit_code=$?
+
+    if [ -n "$INSTANCE_ID" ]; then
+        echo ""
+        echo -e "${YELLOW}Cleaning up instance: $INSTANCE_ID${NC}"
+        aws ec2 terminate-instances --instance-ids "$INSTANCE_ID" --region "$AWS_REGION" >/dev/null 2>&1 || true
+        echo -e "${GREEN}Instance termination initiated${NC}"
+    fi
+
+    # Clean up temporary files
+    rm -f /tmp/burst-perf-scripts.tar.gz 2>/dev/null || true
+
+    exit $exit_code
+}
+
+trap cleanup EXIT INT TERM
+
+# Print usage
+print_usage() {
+    echo "Usage: $0 [options]"
+    echo ""
+    echo "Options:"
+    echo "  --instance-type TYPE    EC2 instance type (required)"
+    echo "  --init-script SCRIPT    Initialization script name (required)"
+    echo "  --archives LIST         Comma-separated list of archives (required)"
+    echo "  --binary-path PATH      Path to burst-downloader binary (required)"
+    echo "  --results-prefix PREFIX S3 prefix for results (required)"
+    echo "  --help                  Show this help message"
+    echo ""
+    echo "Example:"
+    echo "  $0 --instance-type i7ie.xlarge --init-script setup_btrfs.sh \\"
+    echo "     --archives verysmall,small,medium --binary-path ./burst-downloader \\"
+    echo "     --results-prefix perf-run-2025-01-08"
+}
+
+# Parse arguments
+INSTANCE_TYPE=""
+INIT_SCRIPT=""
+ARCHIVES=""
+BINARY_PATH=""
+RESULTS_PREFIX=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --instance-type)
+            INSTANCE_TYPE="$2"
+            shift 2
+            ;;
+        --init-script)
+            INIT_SCRIPT="$2"
+            shift 2
+            ;;
+        --archives)
+            ARCHIVES="$2"
+            shift 2
+            ;;
+        --binary-path)
+            BINARY_PATH="$2"
+            shift 2
+            ;;
+        --results-prefix)
+            RESULTS_PREFIX="$2"
+            shift 2
+            ;;
+        --help)
+            print_usage
+            exit 0
+            ;;
+        *)
+            echo -e "${RED}Unknown option: $1${NC}"
+            print_usage
+            exit 1
+            ;;
+    esac
+done
+
+# Validate required arguments
+if [ -z "$INSTANCE_TYPE" ] || [ -z "$INIT_SCRIPT" ] || [ -z "$ARCHIVES" ] || \
+   [ -z "$BINARY_PATH" ] || [ -z "$RESULTS_PREFIX" ]; then
+    echo -e "${RED}Error: Missing required arguments${NC}"
+    print_usage
+    exit 1
+fi
+
+if [ ! -f "$BINARY_PATH" ]; then
+    echo -e "${RED}Error: Binary not found: $BINARY_PATH${NC}"
+    exit 1
+fi
+
+echo ""
+echo -e "${BLUE}============================================${NC}"
+echo -e "${BLUE}BURST Performance Test Orchestration${NC}"
+echo -e "${BLUE}============================================${NC}"
+echo ""
+echo "Configuration:"
+echo "  Instance Type: $INSTANCE_TYPE"
+echo "  Init Script: $INIT_SCRIPT"
+echo "  Archives: $ARCHIVES"
+echo "  Binary Path: $BINARY_PATH"
+echo "  Results Prefix: $RESULTS_PREFIX"
+echo "  AWS Region: $AWS_REGION"
+echo ""
+
+# Step 1: Create scripts tarball
+echo -e "${BLUE}Step 1: Creating scripts tarball${NC}"
+SCRIPTS_TARBALL="/tmp/burst-perf-scripts.tar.gz"
+tar -czf "$SCRIPTS_TARBALL" -C "$SCRIPT_DIR" \
+    ec2_run_tests.sh \
+    aggregate_results.sh \
+    init_scripts/
+echo -e "${GREEN}Scripts tarball created: $SCRIPTS_TARBALL${NC}"
+
+# Step 2: Upload binary and scripts to S3
+echo ""
+echo -e "${BLUE}Step 2: Uploading binary and scripts to S3${NC}"
+
+# Generate unique prefix for this run
+RUN_ID=$(date +%Y%m%d-%H%M%S)-$(head -c 4 /dev/urandom | xxd -p)
+S3_RUN_PREFIX="runs/$RUN_ID"
+
+BINARY_S3_PATH="s3://$PERF_BUCKET/$S3_RUN_PREFIX/burst-downloader"
+SCRIPTS_S3_PATH="s3://$PERF_BUCKET/$S3_RUN_PREFIX/scripts.tar.gz"
+
+aws s3 cp "$BINARY_PATH" "$BINARY_S3_PATH" --region "$AWS_REGION"
+echo -e "${GREEN}Binary uploaded to: $BINARY_S3_PATH${NC}"
+
+aws s3 cp "$SCRIPTS_TARBALL" "$SCRIPTS_S3_PATH" --region "$AWS_REGION"
+echo -e "${GREEN}Scripts uploaded to: $SCRIPTS_S3_PATH${NC}"
+
+# Step 3: Launch EC2 spot instance
+echo ""
+echo -e "${BLUE}Step 3: Launching EC2 spot instance${NC}"
+
+# Read bootstrap script and encode as base64 for user-data
+USER_DATA=$(base64 -w0 "$SCRIPT_DIR/ec2_bootstrap.sh")
+
+# Launch instance with tags
+INSTANCE_ID=$(aws ec2 run-instances \
+    --image-id "$UBUNTU_AMI" \
+    --instance-type "$INSTANCE_TYPE" \
+    --instance-market-options 'MarketType=spot' \
+    --instance-initiated-shutdown-behavior terminate \
+    --iam-instance-profile "Name=$INSTANCE_PROFILE" \
+    --security-groups "$SECURITY_GROUP" \
+    --user-data "$USER_DATA" \
+    --tag-specifications "ResourceType=instance,Tags=[
+        {Key=Name,Value=burst-perf-test-$INSTANCE_TYPE},
+        {Key=BurstBinaryS3Path,Value=$BINARY_S3_PATH},
+        {Key=BurstScriptsS3Path,Value=$SCRIPTS_S3_PATH},
+        {Key=BurstResultsPrefix,Value=$RESULTS_PREFIX},
+        {Key=BurstInitScript,Value=$INIT_SCRIPT},
+        {Key=BurstTestArchives,Value=$ARCHIVES}
+    ]" \
+    --query 'Instances[0].InstanceId' \
+    --output text \
+    --region "$AWS_REGION")
+
+echo -e "${GREEN}Instance launched: $INSTANCE_ID${NC}"
+
+# Step 4: Wait for instance to be running
+echo ""
+echo -e "${BLUE}Step 4: Waiting for instance to start${NC}"
+aws ec2 wait instance-running --instance-ids "$INSTANCE_ID" --region "$AWS_REGION"
+echo -e "${GREEN}Instance is running${NC}"
+
+# Get instance public IP
+INSTANCE_IP=$(aws ec2 describe-instances \
+    --instance-ids "$INSTANCE_ID" \
+    --query 'Reservations[0].Instances[0].PublicIpAddress' \
+    --output text \
+    --region "$AWS_REGION")
+echo "Instance IP: $INSTANCE_IP"
+
+# Step 5: Wait for instance status checks
+echo ""
+echo -e "${BLUE}Step 5: Waiting for instance status checks${NC}"
+aws ec2 wait instance-status-ok --instance-ids "$INSTANCE_ID" --region "$AWS_REGION"
+echo -e "${GREEN}Instance status checks passed${NC}"
+
+# Step 6: Wait for bootstrap to complete (check for marker file via SSM)
+echo ""
+echo -e "${BLUE}Step 6: Waiting for bootstrap to complete${NC}"
+
+BOOTSTRAP_TIMEOUT=600  # 10 minutes
+BOOTSTRAP_START=$(date +%s)
+
+while true; do
+    ELAPSED=$(($(date +%s) - BOOTSTRAP_START))
+    if [ $ELAPSED -gt $BOOTSTRAP_TIMEOUT ]; then
+        echo -e "${RED}Bootstrap timeout exceeded${NC}"
+        exit 1
+    fi
+
+    # Check for bootstrap completion marker via SSM
+    COMMAND_ID=$(aws ssm send-command \
+        --instance-ids "$INSTANCE_ID" \
+        --document-name "AWS-RunShellScript" \
+        --parameters 'commands=["test -f /opt/burst-perf/.bootstrap_complete && echo READY || echo WAITING"]' \
+        --query 'Command.CommandId' \
+        --output text \
+        --region "$AWS_REGION" 2>/dev/null) || {
+        echo "  Waiting for SSM agent... ($ELAPSED s)"
+        sleep 10
+        continue
+    }
+
+    # Wait for command to complete
+    sleep 5
+
+    # Get command output
+    OUTPUT=$(aws ssm get-command-invocation \
+        --command-id "$COMMAND_ID" \
+        --instance-id "$INSTANCE_ID" \
+        --query 'StandardOutputContent' \
+        --output text \
+        --region "$AWS_REGION" 2>/dev/null) || OUTPUT=""
+
+    if [[ "$OUTPUT" == *"READY"* ]]; then
+        echo -e "${GREEN}Bootstrap complete${NC}"
+        break
+    fi
+
+    echo "  Bootstrap in progress... ($ELAPSED s)"
+    sleep 10
+done
+
+# Step 7: Trigger test execution via SSM
+echo ""
+echo -e "${BLUE}Step 7: Starting performance tests${NC}"
+
+COMMAND_ID=$(aws ssm send-command \
+    --instance-ids "$INSTANCE_ID" \
+    --document-name "AWS-RunShellScript" \
+    --parameters 'commands=["sudo -u ubuntu /opt/burst-perf/scripts/ec2_run_tests.sh"]' \
+    --timeout-seconds 7200 \
+    --query 'Command.CommandId' \
+    --output text \
+    --region "$AWS_REGION")
+
+echo "SSM Command ID: $COMMAND_ID"
+echo "Tests started, waiting for completion..."
+
+# Step 8: Wait for tests to complete (instance will self-terminate)
+echo ""
+echo -e "${BLUE}Step 8: Waiting for tests to complete${NC}"
+
+TEST_TIMEOUT=7200  # 2 hours
+TEST_START=$(date +%s)
+
+while true; do
+    ELAPSED=$(($(date +%s) - TEST_START))
+    if [ $ELAPSED -gt $TEST_TIMEOUT ]; then
+        echo -e "${RED}Test timeout exceeded${NC}"
+        exit 1
+    fi
+
+    # Check instance state
+    STATE=$(aws ec2 describe-instances \
+        --instance-ids "$INSTANCE_ID" \
+        --query 'Reservations[0].Instances[0].State.Name' \
+        --output text \
+        --region "$AWS_REGION" 2>/dev/null) || STATE="unknown"
+
+    if [ "$STATE" = "terminated" ] || [ "$STATE" = "shutting-down" ]; then
+        echo -e "${GREEN}Instance is terminating (tests completed)${NC}"
+        INSTANCE_ID=""  # Prevent cleanup from trying to terminate again
+        break
+    fi
+
+    # Check SSM command status
+    STATUS=$(aws ssm get-command-invocation \
+        --command-id "$COMMAND_ID" \
+        --instance-id "$INSTANCE_ID" \
+        --query 'Status' \
+        --output text \
+        --region "$AWS_REGION" 2>/dev/null) || STATUS="unknown"
+
+    if [ "$STATUS" = "Success" ]; then
+        echo -e "${GREEN}Tests completed successfully${NC}"
+        break
+    elif [ "$STATUS" = "Failed" ] || [ "$STATUS" = "Cancelled" ] || [ "$STATUS" = "TimedOut" ]; then
+        echo -e "${RED}Tests failed with status: $STATUS${NC}"
+        # Get command output for debugging
+        aws ssm get-command-invocation \
+            --command-id "$COMMAND_ID" \
+            --instance-id "$INSTANCE_ID" \
+            --region "$AWS_REGION" || true
+        exit 1
+    fi
+
+    MINUTES=$((ELAPSED / 60))
+    echo "  Tests in progress... ($MINUTES min elapsed)"
+    sleep 30
+done
+
+# Step 9: Verify results uploaded
+echo ""
+echo -e "${BLUE}Step 9: Verifying results${NC}"
+
+RESULTS_PATH="s3://$RESULTS_BUCKET/$RESULTS_PREFIX/${INSTANCE_TYPE}-${INIT_SCRIPT%.sh}.csv"
+if aws s3 ls "$RESULTS_PATH" --region "$AWS_REGION" >/dev/null 2>&1; then
+    echo -e "${GREEN}Results found at: $RESULTS_PATH${NC}"
+
+    # Download and display results
+    echo ""
+    echo "Results:"
+    aws s3 cp "$RESULTS_PATH" - --region "$AWS_REGION"
+else
+    echo -e "${RED}Results not found at: $RESULTS_PATH${NC}"
+    exit 1
+fi
+
+# Cleanup S3 run artifacts
+echo ""
+echo -e "${BLUE}Cleaning up S3 run artifacts${NC}"
+aws s3 rm "s3://$PERF_BUCKET/$S3_RUN_PREFIX/" --recursive --region "$AWS_REGION" >/dev/null 2>&1 || true
+
+echo ""
+echo -e "${GREEN}============================================${NC}"
+echo -e "${GREEN}Performance test completed successfully${NC}"
+echo -e "${GREEN}============================================${NC}"


### PR DESCRIPTION
This should support running a matrix of archives × ec2 instance types on
any particular point in the git history. Results are saved to a results
bucket. This should allow for performance comparisons relaese to
release.

A script is also provided to create test fixtures in S3, though this only needs to be run once and that has been completed.